### PR TITLE
Release v1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "vitest": "^3.0.5",
         "web-vitals": "^5.1.0"
       },
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     "node_modules/@acemir/cssom": {
       "version": "0.9.31",
@@ -12412,5 +12412,5 @@
       }
     }
   },
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "petra-pinterest",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "node --max-http-header-size=32768 node_modules/vite/bin/vite.js dev --port 3000",

--- a/src/types/pins.ts
+++ b/src/types/pins.ts
@@ -3,7 +3,7 @@ export const PIN_STATUS = {
   draft: { color: 'slate' },
   generate_metadata: { color: 'violet' },
   generating_metadata: { color: 'violet' },
-  metadata_created: { color: 'teal' },
+  metadata_created: { color: 'blue' },
   published: { color: 'emerald' },
   error: { color: 'red' },
   deleted: { color: 'gray' },
@@ -90,7 +90,7 @@ export function getStatusBadgeClasses(status: PinStatus): string {
   const colorMap: Record<string, string> = {
     slate: 'bg-slate-100 text-slate-700',
     violet: 'bg-violet-100 text-violet-700',
-    teal: 'bg-teal-100 text-teal-700',
+    blue: 'bg-blue-100 text-blue-700',
     emerald: 'bg-emerald-100 text-emerald-700',
     red: 'bg-red-100 text-red-700',
     gray: 'bg-gray-100 text-gray-500',


### PR DESCRIPTION
## Summary
- Bumps version to v1.0.2
- Fixes metadata_created badge color from teal to blue for better visual distinction from the published (emerald) badge

## On merge
Merging will auto-create the git tag `v1.0.2` and a GitHub Release via the CI workflow.