### PR TITLE
Release v1.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "vitest": "^3.0.5",
         "web-vitals": "^5.1.0"
       },
-      "version": "1.2.2"
+      "version": "1.2.3"
     },
     "node_modules/@acemir/cssom": {
       "version": "0.9.31",
@@ -12412,5 +12412,5 @@
       }
     }
   },
-  "version": "1.2.2"
+  "version": "1.2.3"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "petra-pinterest",
   "private": true,
-  "version": "1.2.2",
+  "version": "1.2.3",
   "type": "module",
   "scripts": {
     "dev": "node --max-http-header-size=32768 node_modules/vite/bin/vite.js dev --port 3000",

--- a/src/lib/hooks/use-blog-projects.ts
+++ b/src/lib/hooks/use-blog-projects.ts
@@ -46,7 +46,6 @@ export function useCreateBlogProject() {
             tenant_id: 'temp',
             name: newProject.name,
             blog_url: newProject.blog_url,
-            rss_url: newProject.rss_url ?? null,
             sitemap_url: newProject.sitemap_url ?? null,
             scraping_frequency: newProject.scraping_frequency ?? 'manual',
             description: newProject.description ?? null,

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -123,8 +123,6 @@
     "placeholderName": "Projektname",
     "fieldBlogUrl": "Blog-URL",
     "placeholderBlogUrl": "https://meinblog.de",
-    "fieldRssUrl": "RSS-URL",
-    "placeholderRssUrl": "https://meinblog.de/feed",
     "fieldSitemapUrl": "Sitemap-URL",
     "placeholderSitemapUrl": "https://meinblog.de/sitemap.xml",
     "fieldDescription": "Beschreibung",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -123,8 +123,6 @@
     "placeholderName": "Project name",
     "fieldBlogUrl": "Blog URL",
     "placeholderBlogUrl": "https://myblog.com",
-    "fieldRssUrl": "RSS URL",
-    "placeholderRssUrl": "https://myblog.com/feed",
     "fieldSitemapUrl": "Sitemap URL",
     "placeholderSitemapUrl": "https://myblog.com/sitemap.xml",
     "fieldDescription": "Description",

--- a/src/routes/_authed/projects/$projectId/index.tsx
+++ b/src/routes/_authed/projects/$projectId/index.tsx
@@ -27,48 +27,19 @@ export const Route = createFileRoute('/_authed/projects/$projectId/')({
 const basicInfoFields: FieldConfig[] = [
   { key: 'name', labelKey: 'projectBranding.fieldName', placeholderKey: 'projectBranding.placeholderName', type: 'input' },
   { key: 'blog_url', labelKey: 'projectBranding.fieldBlogUrl', placeholderKey: 'projectBranding.placeholderBlogUrl', type: 'input' },
-  { key: 'rss_url', labelKey: 'projectBranding.fieldRssUrl', placeholderKey: 'projectBranding.placeholderRssUrl', type: 'input' },
   { key: 'sitemap_url', labelKey: 'projectBranding.fieldSitemapUrl', placeholderKey: 'projectBranding.placeholderSitemapUrl', type: 'input' },
   { key: 'description', labelKey: 'projectBranding.fieldDescription', placeholderKey: 'projectBranding.placeholderDescription', type: 'textarea' },
-  { key: 'language', labelKey: 'projectBranding.fieldLanguage', placeholderKey: 'projectBranding.placeholderLanguage', type: 'input' },
 ]
 
 const scrapingFields: FieldConfig[] = [
   { key: 'scraping_frequency', labelKey: 'projectBranding.fieldScrapingFrequency', type: 'frequency-select' },
 ]
 
-const brandContentFields: FieldConfig[] = [
-  { key: 'brand_voice', labelKey: 'projectBranding.fieldBrandVoice', placeholderKey: 'projectBranding.placeholderBrandVoice', type: 'textarea' },
-  { key: 'blog_niche', labelKey: 'projectBranding.fieldBlogNiche', placeholderKey: 'projectBranding.placeholderBlogNiche', type: 'input' },
-  { key: 'content_type', labelKey: 'projectBranding.fieldContentType', placeholderKey: 'projectBranding.placeholderContentType', type: 'input' },
-  { key: 'target_audience', labelKey: 'projectBranding.fieldTargetAudience', placeholderKey: 'projectBranding.placeholderTargetAudience', type: 'textarea' },
-  { key: 'value_proposition', labelKey: 'projectBranding.fieldValueProposition', placeholderKey: 'projectBranding.placeholderValueProposition', type: 'textarea' },
-  { key: 'general_keywords', labelKey: 'projectBranding.fieldGeneralKeywords', placeholderKey: 'projectBranding.placeholderGeneralKeywords', type: 'textarea' },
-]
-
-const visualStyleFields: FieldConfig[] = [
-  { key: 'visual_style', labelKey: 'projectBranding.fieldVisualStyle', placeholderKey: 'projectBranding.placeholderVisualStyle', type: 'input' },
-  { key: 'style_options', labelKey: 'projectBranding.fieldStyleOptions', placeholderKey: 'projectBranding.placeholderStyleOptions', type: 'textarea' },
-  { key: 'color_palette', labelKey: 'projectBranding.fieldColorPalette', placeholderKey: 'projectBranding.placeholderColorPalette', type: 'input' },
-  { key: 'main_motifs', labelKey: 'projectBranding.fieldMainMotifs', placeholderKey: 'projectBranding.placeholderMainMotifs', type: 'textarea' },
-  { key: 'visual_audience', labelKey: 'projectBranding.fieldVisualAudience', placeholderKey: 'projectBranding.placeholderVisualAudience', type: 'textarea' },
-  { key: 'lighting_description', labelKey: 'projectBranding.fieldLightingDescription', placeholderKey: 'projectBranding.placeholderLightingDescription', type: 'textarea' },
-]
-
-const aiInstructionsFields: FieldConfig[] = [
-  { key: 'text_instructions', labelKey: 'projectBranding.fieldTextInstructions', placeholderKey: 'projectBranding.placeholderTextInstructions', type: 'textarea' },
-  { key: 'additional_instructions', labelKey: 'projectBranding.fieldAdditionalInstructions', placeholderKey: 'projectBranding.placeholderAdditionalInstructions', type: 'textarea' },
-  { key: 'topic_context', labelKey: 'projectBranding.fieldTopicContext', placeholderKey: 'projectBranding.placeholderTopicContext', type: 'textarea' },
-]
-
-type SectionKey = 'basicInfo' | 'scraping' | 'brandContent' | 'visualStyle' | 'aiInstructions'
+type SectionKey = 'basicInfo' | 'scraping'
 
 const SECTIONS: { key: SectionKey; titleKey: string; fields: FieldConfig[] }[] = [
   { key: 'basicInfo', titleKey: 'projectBranding.sectionBasicInfo', fields: basicInfoFields },
   { key: 'scraping', titleKey: 'projectBranding.sectionScraping', fields: scrapingFields },
-  { key: 'brandContent', titleKey: 'projectBranding.sectionBrandContent', fields: brandContentFields },
-  { key: 'visualStyle', titleKey: 'projectBranding.sectionVisualStyle', fields: visualStyleFields },
-  { key: 'aiInstructions', titleKey: 'projectBranding.sectionAiInstructions', fields: aiInstructionsFields },
 ]
 
 // --- Helper components ---
@@ -148,12 +119,10 @@ function BasicInfoContent({ project }: { project: BlogProject }) {
     <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
       <FieldDisplay label={t('projectBranding.fieldName')} value={project.name} />
       <FieldDisplay label={t('projectBranding.fieldBlogUrl')} value={project.blog_url} isUrl />
-      <FieldDisplay label={t('projectBranding.fieldRssUrl')} value={project.rss_url} isUrl />
       <FieldDisplay label={t('projectBranding.fieldSitemapUrl')} value={project.sitemap_url} isUrl />
       <div className="sm:col-span-2">
         <FieldDisplay label={t('projectBranding.fieldDescription')} value={project.description} />
       </div>
-      <FieldDisplay label={t('projectBranding.fieldLanguage')} value={project.language} />
     </dl>
   )
 }
@@ -177,22 +146,6 @@ function ScrapingContent({ project }: { project: BlogProject }) {
         <dt className="text-sm font-medium text-muted-foreground">{t('projectBranding.fieldCreatedAt')}</dt>
         <dd className="text-sm">{formatDate(project.created_at)}</dd>
       </div>
-    </dl>
-  )
-}
-
-function GenericSectionContent({ project, fields }: { project: BlogProject; fields: FieldConfig[] }) {
-  const { t } = useTranslation()
-  return (
-    <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-      {fields.map((field) => (
-        <div key={field.key} className={field.type === 'textarea' ? 'sm:col-span-2' : ''}>
-          <FieldDisplay
-            label={t(field.labelKey)}
-            value={project[field.key as keyof BlogProject] as string | null}
-          />
-        </div>
-      ))}
     </dl>
   )
 }
@@ -253,30 +206,6 @@ function ProjectDetail() {
               onEdit={() => setEditSection('scraping')}
             >
               <ScrapingContent project={project} />
-            </SectionCard>
-
-            {/* Brand & Content */}
-            <SectionCard
-              title={t('projectBranding.sectionBrandContent')}
-              onEdit={() => setEditSection('brandContent')}
-            >
-              <GenericSectionContent project={project} fields={brandContentFields} />
-            </SectionCard>
-
-            {/* Visual Style */}
-            <SectionCard
-              title={t('projectBranding.sectionVisualStyle')}
-              onEdit={() => setEditSection('visualStyle')}
-            >
-              <GenericSectionContent project={project} fields={visualStyleFields} />
-            </SectionCard>
-
-            {/* AI Instructions */}
-            <SectionCard
-              title={t('projectBranding.sectionAiInstructions')}
-              onEdit={() => setEditSection('aiInstructions')}
-            >
-              <GenericSectionContent project={project} fields={aiInstructionsFields} />
             </SectionCard>
 
             {/* Gemini API Key */}

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -67,7 +67,6 @@ export function buildBlogProject(overrides: Partial<BlogProject> = {}): BlogProj
     tenant_id: 'test-tenant-id',
     name: 'Test Blog',
     blog_url: 'https://example.com',
-    rss_url: null,
     sitemap_url: null,
     scraping_frequency: 'manual',
     description: null,

--- a/src/types/blog-projects.ts
+++ b/src/types/blog-projects.ts
@@ -3,7 +3,6 @@ export interface BlogProject {
   tenant_id: string
   name: string
   blog_url: string
-  rss_url: string | null
   sitemap_url: string | null
   scraping_frequency: 'daily' | 'weekly' | 'manual'
   description: string | null
@@ -28,7 +27,6 @@ export interface BlogProject {
 }
 
 export type BlogProjectInsert = Pick<BlogProject, 'name' | 'blog_url'> & {
-  rss_url?: string | null
   sitemap_url?: string | null
   scraping_frequency?: 'daily' | 'weekly' | 'manual'
   description?: string | null
@@ -38,7 +36,6 @@ export type BlogProjectUpdate = {
   id: string
   name?: string
   blog_url?: string
-  rss_url?: string | null
   sitemap_url?: string | null
   scraping_frequency?: 'daily' | 'weekly' | 'manual'
   description?: string | null


### PR DESCRIPTION
Bumps version to v1.2.3.

Also includes the cleanup from the previous branch:
- Drop `rss_url` column (DB migration + types + hooks + locales)
- Hide dormant branding/language section cards from the project detail UI until AI generation consumes them