### PR TITLE
Release v1.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "vitest": "^3.0.5",
         "web-vitals": "^5.1.0"
       },
-      "version": "1.2.3"
+      "version": "1.2.4"
     },
     "node_modules/@acemir/cssom": {
       "version": "0.9.31",
@@ -12412,5 +12412,5 @@
       }
     }
   },
-  "version": "1.2.3"
+  "version": "1.2.4"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "petra-pinterest",
   "private": true,
-  "version": "1.2.3",
+  "version": "1.2.4",
   "type": "module",
   "scripts": {
     "dev": "node --max-http-header-size=32768 node_modules/vite/bin/vite.js dev --port 3000",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -278,8 +278,9 @@
   "createPin": {
     "titleSingle": "Pin erstellen",
     "titleMultiple": "{{count}} Pins erstellen",
-    "fieldArticle": "Artikel *",
+    "fieldArticle": "Artikel (optional)",
     "placeholderArticle": "Artikel auswählen",
+    "noArticleOption": "Keiner (kein Artikel)",
     "noArticles": "Keine Artikel gefunden. Füge zuerst Artikel zu diesem Projekt hinzu.",
     "fieldBoard": "Board (optional)",
     "placeholderBoard": "Board auswählen (optional)",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -278,8 +278,9 @@
   "createPin": {
     "titleSingle": "Create Pin",
     "titleMultiple": "Create {{count}} Pins",
-    "fieldArticle": "Article *",
+    "fieldArticle": "Article (optional)",
     "placeholderArticle": "Select an article",
+    "noArticleOption": "None (no article)",
     "noArticles": "No articles found. Add articles to this project first.",
     "fieldBoard": "Board (optional)",
     "placeholderBoard": "Select a board (optional)",

--- a/src/routes/_authed/projects/$projectId/create-pin.tsx
+++ b/src/routes/_authed/projects/$projectId/create-pin.tsx
@@ -55,10 +55,6 @@ function CreatePinPage() {
       toast.error(t('createPin.validationMediaRequired'))
       return
     }
-    if (!selectedArticleId) {
-      toast.error(t('createPin.validationArticleRequired'))
-      return
-    }
 
     setIsUploading(true)
 
@@ -78,7 +74,7 @@ function CreatePinPage() {
       await createPinsMutation.mutateAsync(
         uploadedFiles.map(({ path, mediaType }) => ({
           blog_project_id: projectId,
-          blog_article_id: selectedArticleId,
+          blog_article_id: selectedArticleId || null,
           image_path: path,
           media_type: mediaType,
           pinterest_board_id: selectedBoardId || null,
@@ -140,6 +136,21 @@ function CreatePinPage() {
                   <CommandList>
                     <CommandEmpty>{t('createPin.noArticles')}</CommandEmpty>
                     <CommandGroup>
+                      <CommandItem
+                        value="__none__"
+                        onSelect={() => {
+                          setSelectedArticleId('')
+                          setArticlePopoverOpen(false)
+                        }}
+                      >
+                        <Check
+                          className={cn(
+                            'mr-2 h-4 w-4',
+                            !selectedArticleId ? 'opacity-100' : 'opacity-0'
+                          )}
+                        />
+                        <span className="text-muted-foreground">{t('createPin.noArticleOption')}</span>
+                      </CommandItem>
                       {articles.map((article) => (
                         <CommandItem
                           key={article.id}
@@ -269,7 +280,7 @@ function CreatePinPage() {
             <Button
               type="button"
               onClick={handleSubmit}
-              disabled={isUploading || files.length === 0 || !selectedArticleId}
+              disabled={isUploading || files.length === 0}
             >
               {isUploading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               {submitLabel}

--- a/src/types/pins.ts
+++ b/src/types/pins.ts
@@ -28,7 +28,7 @@ export interface Pin {
   id: string
   tenant_id: string
   blog_project_id: string
-  blog_article_id: string
+  blog_article_id: string | null
   pinterest_board_id: string | null
   pinterest_board_name: string | null
   image_path: string | null
@@ -50,7 +50,7 @@ export interface Pin {
 
 export interface PinInsert {
   blog_project_id: string
-  blog_article_id: string
+  blog_article_id: string | null
   image_path: string
   media_type?: 'image' | 'video'
   pinterest_board_id?: string | null

--- a/supabase/functions/_shared/gemini.ts
+++ b/supabase/functions/_shared/gemini.ts
@@ -134,14 +134,17 @@ async function fetchImageAsBase64(
  * Uses Gemini 2.5 Flash with vision to analyze article content + pin image.
  */
 export async function generatePinMetadata(
-  articleTitle: string,
-  articleContent: string,
+  articleTitle: string | null | undefined,
+  articleContent: string | null | undefined,
   pinImageUrl: string,
   systemPrompt: string | undefined,
   apiKey: string,
   mediaType: 'image' | 'video' = 'image'
 ): Promise<GeneratedMetadata> {
-  const truncatedContent = articleContent.slice(0, 4000)
+  const articleSection = articleTitle
+    ? `\n\nArticle Title: ${articleTitle}\n\nArticle Content: ${(articleContent ?? '').slice(0, 4000)}`
+    : `\n\n[No article linked — generate metadata based solely on the image.]`
+  const promptText = `Pin Type: ${mediaType === 'video' ? 'Video' : 'Image'}${articleSection}`
   const imageData = await fetchImageAsBase64(pinImageUrl)
 
   const ai = new GoogleGenAI({ apiKey })
@@ -149,7 +152,7 @@ export async function generatePinMetadata(
     model: 'gemini-2.5-flash',
     contents: [
       {
-        text: `Pin Type: ${mediaType === 'video' ? 'Video' : 'Image'}\n\nArticle Title: ${articleTitle}\n\nArticle Content: ${truncatedContent}`,
+        text: promptText,
       },
       {
         inlineData: { mimeType: imageData.mimeType, data: imageData.data },

--- a/supabase/functions/publish-scheduled-pins/index.ts
+++ b/supabase/functions/publish-scheduled-pins/index.ts
@@ -136,8 +136,9 @@ Deno.serve(async (req) => {
           if (pin.alt_text) {
             payload.alt_text = pin.alt_text.substring(0, 500)
           }
-          if (pin.blog_articles?.url) {
-            payload.link = pin.blog_articles.url
+          const linkUrl = pin.alternate_url ?? pin.blog_articles?.url
+          if (linkUrl) {
+            payload.link = linkUrl
           }
 
           // Call Pinterest API

--- a/supabase/migrations/00017_make_article_optional.sql
+++ b/supabase/migrations/00017_make_article_optional.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.pins ALTER COLUMN blog_article_id DROP NOT NULL;


### PR DESCRIPTION
## Summary
- Makes article selection optional when creating pins
- AI metadata generation falls back to image-only analysis when no article is linked
- Pins can now be published to Pinterest with only a board assigned (no article URL required)

## Changes
- DB migration: drops NOT NULL on `pins.blog_article_id`
- TypeScript types: `blog_article_id` is now `string | null`
- Create-pin UI: article field is optional with "None" option in combobox
- Gemini clients (Node.js + Deno): conditional prompt when no article provided
- Server metadata functions: use `pin.blog_project_id` directly for API key lookup
- Edge functions: removed hard article check; fixed `alternate_url` fallback in scheduled publisher

Bumps version to v1.2.4.