### PR TITLE
Release v1.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "vitest": "^3.0.5",
         "web-vitals": "^5.1.0"
       },
-      "version": "1.3.0"
+      "version": "1.3.1"
     },
     "node_modules/@acemir/cssom": {
       "version": "0.9.31",
@@ -12412,5 +12412,5 @@
       }
     }
   },
-  "version": "1.3.0"
+  "version": "1.3.1"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "petra-pinterest",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "scripts": {
     "dev": "node --max-http-header-size=32768 node_modules/vite/bin/vite.js dev --port 3000",

--- a/src/components/calendar/calendar-day-cell.tsx
+++ b/src/components/calendar/calendar-day-cell.tsx
@@ -179,7 +179,7 @@ const CalendarDayCellComponent = ({
                 {pin.title || t('common.untitled')}
               </span>
               <div className="shrink-0 w-7 h-7 rounded overflow-hidden">
-                <PinMediaPreview pin={pin} />
+                <PinMediaPreview pin={pin} displayWidth={48} />
               </div>
             </div>
           ) : (
@@ -204,7 +204,7 @@ const CalendarDayCellComponent = ({
                   height: `${thumbnailSize}px`,
                 }}
               >
-                <PinMediaPreview pin={pin} />
+                <PinMediaPreview pin={pin} displayWidth={48} />
               </div>
             </div>
           )
@@ -244,7 +244,7 @@ const CalendarDayCellComponent = ({
                         {pin.title || t('common.untitled')}
                       </span>
                       <div className="shrink-0 w-8 h-8 rounded overflow-hidden">
-                        <PinMediaPreview pin={pin} />
+                        <PinMediaPreview pin={pin} displayWidth={48} />
                       </div>
                     </div>
                   ))}

--- a/src/components/calendar/calendar-week-grid.tsx
+++ b/src/components/calendar/calendar-week-grid.tsx
@@ -394,7 +394,7 @@ export function CalendarWeekGrid({
                     >
                       <div className="flex items-center gap-1.5 h-full min-w-0">
                         <div className="w-6 h-6 rounded overflow-hidden shrink-0">
-                          <PinMediaPreview pin={pp.pin} />
+                          <PinMediaPreview pin={pp.pin} displayWidth={48} />
                         </div>
                         <div className="min-w-0 flex-1">
                           <p className="text-xs font-medium text-slate-900 truncate leading-tight">

--- a/src/components/calendar/pin-sidebar.tsx
+++ b/src/components/calendar/pin-sidebar.tsx
@@ -128,7 +128,7 @@ function PinSidebarForm({
     <>
       {/* Pin media */}
       <div className="rounded-lg bg-slate-100 overflow-hidden">
-        <PinMediaPreview pin={pin} className="max-h-[200px] w-full object-contain" />
+        <PinMediaPreview pin={pin} displayWidth={300} className="max-h-[200px] w-full object-contain" />
       </div>
 
       {/* Inline edit form */}

--- a/src/components/pins/article-pin-card.tsx
+++ b/src/components/pins/article-pin-card.tsx
@@ -33,7 +33,7 @@ export function ArticlePinCard({ pin, projectId }: ArticlePinCardProps) {
       className="flex items-center gap-3 rounded-lg border bg-card p-3 transition-colors hover:bg-accent/50"
     >
       <div className="h-14 w-14 shrink-0 overflow-hidden rounded-md bg-slate-100">
-        <PinMediaPreview pin={pin} />
+        <PinMediaPreview pin={pin} displayWidth={48} />
       </div>
       <div className="min-w-0 flex-1">
         <p className={cn('text-sm font-medium truncate', !pin.title && 'italic text-muted-foreground')}>

--- a/src/components/pins/pin-card.tsx
+++ b/src/components/pins/pin-card.tsx
@@ -19,7 +19,7 @@ export function PinCard({ pin, selected, onToggleSelect }: PinCardProps) {
     <div className="group relative overflow-hidden rounded-lg border bg-card shadow-sm transition-shadow hover:shadow-md">
       <Link to="/projects/$projectId/pins/$pinId" params={{ projectId: pin.blog_project_id, pinId: pin.id }} className="block">
         <div className="relative aspect-[2/3] w-full overflow-hidden bg-slate-100">
-          <PinMediaPreview pin={pin} />
+          <PinMediaPreview pin={pin} displayWidth={300} />
 
           {/* Bottom gradient overlay */}
           <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent px-3 pb-3 pt-8">

--- a/src/components/pins/pin-data-table.tsx
+++ b/src/components/pins/pin-data-table.tsx
@@ -148,7 +148,7 @@ export function PinDataTable({
         return (
           <TableCell key={colId}>
             <div className="h-12 w-12 overflow-hidden rounded bg-slate-100">
-              <PinMediaPreview pin={pin} />
+              <PinMediaPreview pin={pin} displayWidth={48} />
             </div>
           </TableCell>
         )

--- a/src/components/pins/pin-media-preview.tsx
+++ b/src/components/pins/pin-media-preview.tsx
@@ -13,7 +13,7 @@ interface PinMediaPreviewProps {
   displayWidth?: number
 }
 
-export function PinMediaPreview({ pin, className, controls = false, displayWidth = 400 }: PinMediaPreviewProps) {
+export function PinMediaPreview({ pin, className, controls = false, displayWidth = 256 }: PinMediaPreviewProps) {
   const { t } = useTranslation()
 
   // Cleaned-up image: published pin with no storage image remaining

--- a/src/components/ui/optimized-image.tsx
+++ b/src/components/ui/optimized-image.tsx
@@ -15,9 +15,7 @@ function useVercelOptimizedImageProps(src: string, width: number) {
   const encoded = encodeURIComponent(src)
   return {
     src: `/_vercel/image?url=${encoded}&w=${snapToAllowedSize(width)}&q=75`,
-    srcSet: [1, 2]
-      .map(d => `/_vercel/image?url=${encoded}&w=${snapToAllowedSize(width * d)}&q=75 ${d}x`)
-      .join(', '),
+    srcSet: `/_vercel/image?url=${encoded}&w=${snapToAllowedSize(width)}&q=75 1x`,
   }
 }
 

--- a/src/routes/_authed/projects/$projectId/pins/$pinId.tsx
+++ b/src/routes/_authed/projects/$projectId/pins/$pinId.tsx
@@ -196,7 +196,7 @@ function PinDetail() {
                   className="overflow-hidden rounded-lg shadow-sm bg-white cursor-pointer w-full"
                   onClick={() => setImageDialogOpen(true)}
                 >
-                  <PinMediaPreview pin={pin} className="w-full h-auto object-contain" />
+                  <PinMediaPreview pin={pin} displayWidth={800} className="w-full h-auto object-contain" />
                 </button>
 
                 {/* AI Metadata generation */}
@@ -239,7 +239,7 @@ function PinDetail() {
           <Dialog open={imageDialogOpen} onOpenChange={setImageDialogOpen}>
             <DialogContent className="max-w-4xl p-0 overflow-hidden">
               <DialogTitle className="sr-only">{pin.title || 'Pin media'}</DialogTitle>
-              <PinMediaPreview pin={pin} controls className="w-full h-auto object-contain" />
+              <PinMediaPreview pin={pin} displayWidth={800} controls className="w-full h-auto object-contain" />
             </DialogContent>
           </Dialog>
         </>

--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,7 @@
     ],
     "sizes": [48, 96, 128, 256, 384, 512, 640, 750, 800, 828, 1080, 1200, 1920, 2048, 3840],
     "formats": ["image/webp"],
-    "minimumCacheTTL": 60,
+    "minimumCacheTTL": 31536000,
     "dangerouslyAllowSVG": false
   }
 }


### PR DESCRIPTION
Bumps version to v1.3.1.

## Changes in this release

### Performance
- **Optimize Vercel image transformations by 70-75%** (#21)
  - Reduces image API calls from ~4,085 to ~1,000-1,200/month
  - Remove 2x srcSet density (only use 1x)
  - Increase cache TTL from 60s to 1 year
  - Set correct displayWidth per component (48px thumbnails, 300px cards, 800px detail views)
  - Lower default displayWidth fallback from 400 to 256

Merging this PR will automatically create the git tag and GitHub Release.