### PR TITLE
feat(pins): board selection in quick-edit row expansion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "petra-pinterest",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "petra-pinterest",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "dependencies": {
         "@google/genai": "^1.40.0",
         "@hookform/resolvers": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "petra-pinterest",
   "private": true,
-  "version": "1.7.0",
+  "version": "1.7.1",
   "type": "module",
   "scripts": {
     "dev": "node --max-http-header-size=32768 node_modules/vite/bin/vite.js dev --port 3000",

--- a/src/components/pins/pin-data-table.tsx
+++ b/src/components/pins/pin-data-table.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState, type ReactNode } from 'react'
+import React, { useMemo, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
+import { usePinterestBoards } from '@/lib/hooks/use-pinterest-connection'
 import {
   ArrowUp,
   ArrowDown,
@@ -56,6 +57,8 @@ export function PinDataTable({
 }: PinDataTableProps) {
   const { t } = useTranslation()
   const [expandedPinId, setExpandedPinId] = useState<string | null>(null)
+  const blogProjectId = pins[0]?.blog_project_id ?? ''
+  const { data: boards, isLoading: boardsLoading } = usePinterestBoards(blogProjectId)
 
   const columnDefs = useMemo(() => getColumnsForIds(columns), [columns])
 
@@ -268,9 +271,8 @@ export function PinDataTable({
       </TableHeader>
       <TableBody>
         {sortedPins.map((pin) => (
-          <>
+          <React.Fragment key={pin.id}>
             <TableRow
-              key={pin.id}
               data-state={selectedIds.has(pin.id) ? 'selected' : undefined}
               className={cn(expandedPinId === pin.id && 'border-b-0')}
             >
@@ -291,12 +293,16 @@ export function PinDataTable({
                   )}
                 >
                   <div className="overflow-hidden">
-                    <PinRowExpansion pin={pin} />
+                    <PinRowExpansion
+                      pin={pin}
+                      boards={expandedPinId === pin.id ? boards : undefined}
+                      boardsLoading={expandedPinId === pin.id ? boardsLoading : false}
+                    />
                   </div>
                 </div>
               </TableCell>
             </TableRow>
-          </>
+          </React.Fragment>
         ))}
       </TableBody>
     </Table>

--- a/src/components/pins/pin-row-expansion.tsx
+++ b/src/components/pins/pin-row-expansion.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { memo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { format } from 'date-fns'
 import { CalendarIcon, Clock, X } from 'lucide-react'
@@ -17,8 +17,15 @@ import {
 } from '@/components/ui/select'
 import { ACTIVE_STATUSES, type Pin, type PinStatus } from '@/types/pins'
 
+interface Board {
+  pinterest_board_id: string
+  name: string
+}
+
 interface PinRowExpansionProps {
   pin: Pin
+  boards: Board[] | undefined
+  boardsLoading: boolean
 }
 
 const PRESET_TIMES = [
@@ -30,7 +37,7 @@ const PRESET_TIMES = [
   { label: '21:00', value: '21:00' },
 ]
 
-export function PinRowExpansion({ pin }: PinRowExpansionProps) {
+export const PinRowExpansion = memo(function PinRowExpansion({ pin, boards, boardsLoading }: PinRowExpansionProps) {
   const { t } = useTranslation()
   const locale = useDateLocale()
   const hasMetadata = !!pin.title && !!pin.description
@@ -43,6 +50,21 @@ export function PinRowExpansion({ pin }: PinRowExpansionProps) {
   )
 
   const updatePin = useUpdatePin()
+
+  const handleBoardChange = (value: string) => {
+    if (value === '__none__') {
+      updatePin.mutate({ id: pin.id, pinterest_board_id: null, pinterest_board_name: null })
+    } else {
+      const board = boards?.find((b) => b.pinterest_board_id === value)
+      if (board) {
+        updatePin.mutate({
+          id: pin.id,
+          pinterest_board_id: board.pinterest_board_id,
+          pinterest_board_name: board.name,
+        })
+      }
+    }
+  }
 
   const handleSchedule = () => {
     if (!date || !time) return
@@ -127,6 +149,38 @@ export function PinRowExpansion({ pin }: PinRowExpansionProps) {
                 ))}
               </SelectContent>
             </Select>
+          </div>
+
+          {/* Board Selection */}
+          <div>
+            <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide block mb-2">
+              {t('pinRowExpansion.board')}
+            </label>
+            {boards === undefined && !boardsLoading ? (
+              <p className="text-sm text-muted-foreground">
+                {t('pinRowExpansion.pinterestNotConnected')}
+              </p>
+            ) : (
+              <Select
+                value={pin.pinterest_board_id ?? '__none__'}
+                onValueChange={handleBoardChange}
+                disabled={updatePin.isPending || boardsLoading}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder={t('pinRowExpansion.placeholderBoard')} />
+                </SelectTrigger>
+                <SelectContent className="max-h-64 overflow-y-auto">
+                  <SelectItem value="__none__">
+                    {t('pinRowExpansion.noBoard')}
+                  </SelectItem>
+                  {boards?.map((board) => (
+                    <SelectItem key={board.pinterest_board_id} value={board.pinterest_board_id}>
+                      {board.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
           </div>
 
           {/* Scheduling */}
@@ -228,4 +282,4 @@ export function PinRowExpansion({ pin }: PinRowExpansionProps) {
       </div>
     </div>
   )
-}
+})

--- a/src/lib/server/detect-language.ts
+++ b/src/lib/server/detect-language.ts
@@ -1,0 +1,12 @@
+import { createServerFn } from '@tanstack/react-start'
+import { getCookie, getRequestHeader } from '@tanstack/react-start/server'
+
+export const detectLanguageFn = createServerFn({ method: 'GET' }).handler(async () => {
+  const cookieLang = getCookie('i18next')
+  if (cookieLang === 'de' || cookieLang === 'en') return cookieLang
+
+  const acceptLang = getRequestHeader('accept-language') ?? ''
+  if (/^de\b/.test(acceptLang)) return 'de'
+  if (/^en\b/.test(acceptLang)) return 'en'
+  return 'de'
+})

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -446,7 +446,11 @@
   },
   "pinRowExpansion": {
     "description": "Beschreibung",
-    "altText": "Alternativtext"
+    "altText": "Alternativtext",
+    "board": "Board",
+    "noBoard": "Kein Board",
+    "placeholderBoard": "Board auswaehlen",
+    "pinterestNotConnected": "Pinterest nicht verbunden. Verbinde Pinterest in den Projekteinstellungen."
   },
   "pinTable": {
     "columns": "Spalten",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -446,7 +446,11 @@
   },
   "pinRowExpansion": {
     "description": "Description",
-    "altText": "Alt Text"
+    "altText": "Alt Text",
+    "board": "Board",
+    "noBoard": "No board",
+    "placeholderBoard": "Select a board",
+    "pinterestNotConnected": "Pinterest not connected. Connect in project settings."
   },
   "pinTable": {
     "columns": "Columns",

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -13,6 +13,7 @@ import { Toaster } from 'sonner'
 import { I18nextProvider, useTranslation } from 'react-i18next'
 import i18n from '@/lib/i18n'
 import { fetchUser } from '@/lib/server/auth'
+import { detectLanguageFn } from '@/lib/server/detect-language'
 import '@/styles.css'
 
 const queryClient = new QueryClient({
@@ -36,6 +37,18 @@ export const Route = createRootRoute({
   }),
   beforeLoad: async () => {
     const user = await fetchUser()
+
+    // Server-side only: detect language from cookie or Accept-Language header
+    // to avoid hydration mismatch with client-side LanguageDetector.
+    // The typeof check prevents detectLanguageFn from making an HTTP round-trip
+    // on every client-side navigation.
+    if (typeof window === 'undefined') {
+      const lang = await detectLanguageFn()
+      if (i18n.language !== lang) {
+        await i18n.changeLanguage(lang)
+      }
+    }
+
     return { user }
   },
   component: RootComponent,


### PR DESCRIPTION
## Summary

- Board-Select im Quick-Edit-Panel der Pin-Liste (zwischen Status und Zeitplan): speichert `pinterest_board_id` + `pinterest_board_name` sofort via `updatePin` mutation; scrollbar bei vielen Boards
- Boards werden einmal auf `PinDataTable`-Ebene geladen und nur an die expandierte Zeile weitergegeben — `React.memo` skippt alle anderen 528 Zeilen
- `PinRowExpansion` mit `React.memo` gewrappt um Re-renders beim Toggle zu vermeiden
- Fix: fehlendes `key` Prop — `React.Fragment key={pin.id}` statt Key auf inneren `TableRow`-Geschwistern
- Fix: i18n SSR Hydration-Mismatch — Sprache server-seitig aus `i18next`-Cookie oder `Accept-Language` Header via `createServerFn` in `beforeLoad` erkennen

## Test Plan

- [ ] Board-Select im Quick-Edit erscheint und zeigt alle Pinterest-Boards
- [ ] Board speichert sofort beim Auswaehlen (kein Save-Button noetig)
- [ ] "Kein Board" Option setzt Board zurueck auf null
- [ ] Bei vielen Boards ist die Liste scrollbar
- [ ] Zeile klappt sofort auf (kein 5s Freeze beim ersten Expand)
- [ ] Keine Hydration-Warnings in der Browser-Konsole

🤖 Generated with [Claude Code](https://claude.com/claude-code)