### PR TITLE
feat(pinterest-video): end-to-end video pin support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,10 @@ RESEND_API_KEY=re_xxxxx
 RESEND_FROM_EMAIL=Pinfinity <noreply@example.com>
 # Base URL used to build deep links inside notification e-mails
 APP_URL=https://pinfinity.onlineheldinnen.de
+
+# ffmpeg server (external HTTPS service) — used for video keyframe extraction
+# when publishing video pins without a user-uploaded cover image, and for
+# AI metadata generation on video pins.
+# See https://github.com/theaussie86/ffmpeg-Docker-API
+FFMPEG_SERVER_URL=https://util.weissteiner-automation.com
+FFMPEG_SERVER_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ scripts/migration/data/
 coverage
 
 .trigger
+
+# Git worktrees
+.worktrees

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "petra-pinterest",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "petra-pinterest",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "dependencies": {
         "@google/genai": "^1.40.0",
         "@hookform/resolvers": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "petra-pinterest",
   "private": true,
-  "version": "1.7.0",
+  "version": "1.8.0",
   "type": "module",
   "scripts": {
     "dev": "node --max-http-header-size=32768 node_modules/vite/bin/vite.js dev --port 3000",

--- a/scripts/test-video-publish.ts
+++ b/scripts/test-video-publish.ts
@@ -1,0 +1,253 @@
+/**
+ * E2E test for the Pinterest video publish flow.
+ *
+ * Uses the existing video pin on "Online Heldinnen" that previously failed
+ * (status=error) because the video flow wasn't wired in yet. Resets it to
+ * metadata_created and runs the full publish path:
+ *   register media → upload to S3 → poll → POST /pins with video_id
+ *
+ * Usage:
+ *   npx tsx scripts/test-video-publish.ts [--pin-id <uuid>] [--dry-run]
+ *
+ * Defaults to pin 1432e9ab-8a60-40eb-bf10-de0b23280a0a (Online Heldinnen test video).
+ */
+
+import { config } from 'dotenv'
+import { createClient } from '@supabase/supabase-js'
+
+config({ path: '.env.local' })
+
+// --- env ---
+
+const SUPABASE_URL = process.env.SUPABASE_URL!
+const SUPABASE_SECRET_KEY = process.env.SUPABASE_SECRET_KEY!
+
+if (!SUPABASE_URL || !SUPABASE_SECRET_KEY) {
+  console.error('Missing SUPABASE_URL or SUPABASE_SECRET_KEY in .env.local')
+  process.exit(1)
+}
+
+// --- args ---
+
+const args = process.argv.slice(2)
+const pinIdIdx = args.indexOf('--pin-id')
+const pinIdArg = pinIdIdx !== -1 ? args[pinIdIdx + 1] : undefined
+const DRY_RUN = args.includes('--dry-run')
+const TARGET_PIN_ID = pinIdArg ?? '1432e9ab-8a60-40eb-bf10-de0b23280a0a'
+
+const PINTEREST_API = 'https://api.pinterest.com/v5'
+
+// --- Supabase ---
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SECRET_KEY, {
+  auth: { persistSession: false },
+})
+
+// --- Pinterest helpers (inline, no TanStack deps) ---
+
+async function pinterestFetch<T>(endpoint: string, token: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${PINTEREST_API}${endpoint}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(init?.method && init.method !== 'GET' ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.headers ?? {}),
+    },
+  })
+  if (!res.ok) {
+    const text = await res.text()
+    let msg = `Pinterest ${res.status}: ${res.statusText}`
+    try { msg = `Pinterest ${res.status}: ${JSON.parse(text).message}` } catch {}
+    throw new Error(msg)
+  }
+  return res.json() as Promise<T>
+}
+
+async function registerMedia(token: string) {
+  return pinterestFetch<{ media_id: string; upload_url: string; upload_parameters: Record<string, string> }>(
+    '/media', token, { method: 'POST', body: JSON.stringify({ media_type: 'video' }) }
+  )
+}
+
+async function uploadToS3(reg: Awaited<ReturnType<typeof registerMedia>>, bytes: Uint8Array, filename: string) {
+  const form = new FormData()
+  for (const [k, v] of Object.entries(reg.upload_parameters)) form.append(k, v)
+  form.append('file', new Blob([bytes], { type: 'video/mp4' }), filename)
+  const res = await fetch(reg.upload_url, { method: 'POST', body: form })
+  if (!res.ok) throw new Error(`S3 upload failed: ${res.status} ${res.statusText}`)
+}
+
+async function pollMediaReady(token: string, mediaId: string, timeoutMs = 5 * 60_000) {
+  const deadline = Date.now() + timeoutMs
+  const backoff = [5_000, 10_000, 15_000, 30_000]
+  let step = 0
+  while (true) {
+    const s = await pinterestFetch<{ media_id: string; status: string }>(`/media/${mediaId}`, token, { method: 'GET' })
+    console.log(`  [poll] status=${s.status}`)
+    if (s.status === 'succeeded') return s
+    if (s.status === 'failed') throw new Error(`Pinterest media processing failed for ${mediaId}`)
+    if (Date.now() >= deadline) throw new Error(`Timeout waiting for media ${mediaId}`)
+    const delay = backoff[Math.min(step, backoff.length - 1)]!
+    step++
+    await new Promise(r => setTimeout(r, delay))
+  }
+}
+
+// --- main ---
+
+async function main() {
+  console.log(`\n=== Pinterest Video Publish E2E Test ===`)
+  console.log(`Pin ID   : ${TARGET_PIN_ID}`)
+  console.log(`Dry run  : ${DRY_RUN}\n`)
+
+  // 1. Fetch pin
+  const { data: pin, error: pinErr } = await supabase
+    .from('pins')
+    .select('*, blog_articles(url), blog_projects(pinterest_connection_id, name)')
+    .eq('id', TARGET_PIN_ID)
+    .single()
+
+  if (pinErr || !pin) {
+    console.error('Pin not found:', pinErr?.message)
+    process.exit(1)
+  }
+
+  console.log(`Project  : ${pin.blog_projects?.name}`)
+  console.log(`Status   : ${pin.status}`)
+  console.log(`media_type: ${pin.media_type}`)
+  console.log(`image_path: ${pin.image_path}`)
+  console.log(`board_id : ${pin.pinterest_board_id}`)
+
+  if (pin.media_type !== 'video') {
+    console.error(`\nExpected media_type=video, got: ${pin.media_type}`)
+    process.exit(1)
+  }
+  if (!pin.image_path) {
+    console.error('\nPin has no image_path (video file path).')
+    process.exit(1)
+  }
+  if (!pin.pinterest_board_id) {
+    console.error('\nPin has no board assigned.')
+    process.exit(1)
+  }
+  if (!pin.blog_projects?.pinterest_connection_id) {
+    console.error('\nNo Pinterest connection on this project.')
+    process.exit(1)
+  }
+
+  // 2. Reset to metadata_created if currently in error (or keep if already there)
+  if (pin.status === 'error') {
+    console.log('\nResetting status: error → metadata_created')
+    if (!DRY_RUN) {
+      const { error } = await supabase
+        .from('pins')
+        .update({ status: 'metadata_created', error_message: null })
+        .eq('id', TARGET_PIN_ID)
+      if (error) { console.error('Reset failed:', error.message); process.exit(1) }
+    }
+  } else if (pin.status !== 'metadata_created') {
+    console.error(`\nPin is in status '${pin.status}', can only publish from metadata_created or error.`)
+    process.exit(1)
+  }
+
+  // 3. Get Pinterest access token from Vault
+  console.log('\nFetching Pinterest access token from Vault...')
+  const { data: tokenData, error: tokenErr } = await supabase.rpc(
+    'get_pinterest_access_token',
+    { p_connection_id: pin.blog_projects.pinterest_connection_id }
+  )
+  if (tokenErr || !tokenData) {
+    console.error('Token fetch failed:', tokenErr?.message ?? 'no data')
+    process.exit(1)
+  }
+  const token = tokenData as string
+  console.log('Token retrieved (length:', token.length, ')')
+
+  if (DRY_RUN) {
+    console.log('\n[DRY RUN] Would proceed with video registration + upload. Exiting.')
+    process.exit(0)
+  }
+
+  // 4. Register media slot with Pinterest
+  console.log('\nRegistering media with Pinterest...')
+  const registration = await registerMedia(token)
+  console.log('media_id:', registration.media_id)
+
+  // 5. Fetch video bytes from Supabase Storage
+  const videoUrl = `${SUPABASE_URL}/storage/v1/object/public/pin-images/${pin.image_path}`
+  console.log(`\nFetching video from storage: ${videoUrl}`)
+  const videoRes = await fetch(videoUrl)
+  if (!videoRes.ok) {
+    console.error(`Failed to fetch video: ${videoRes.status} ${videoRes.statusText}`)
+    process.exit(1)
+  }
+  const videoBytes = new Uint8Array(await videoRes.arrayBuffer())
+  console.log(`Video size: ${(videoBytes.length / 1024 / 1024).toFixed(2)} MB`)
+
+  // 6. Upload to Pinterest S3
+  console.log('\nUploading to Pinterest S3...')
+  const filename = pin.image_path.split('/').pop() ?? 'video.mp4'
+  await uploadToS3(registration, videoBytes, filename)
+  console.log('Upload complete.')
+
+  // 7. Poll until ready
+  console.log('\nPolling for Pinterest media processing...')
+  await pollMediaReady(token, registration.media_id)
+  console.log('Media ready!')
+
+  // 8. Build payload
+  interface MediaSource {
+    source_type: string
+    media_id: string
+    cover_image_url?: string
+    cover_image_key_frame_time?: number
+  }
+
+  const mediaSource: MediaSource = {
+    source_type: 'video_id',
+    media_id: registration.media_id,
+  }
+  if (pin.cover_image_path) {
+    mediaSource.cover_image_url = `${SUPABASE_URL}/storage/v1/object/public/pin-images/${pin.cover_image_path}`
+    console.log('Cover: image_url')
+  } else {
+    mediaSource.cover_image_key_frame_time = pin.cover_keyframe_seconds ?? 1
+    console.log(`Cover: keyframe at ${pin.cover_keyframe_seconds ?? 1}s`)
+  }
+
+  const payload: Record<string, unknown> = {
+    board_id: pin.pinterest_board_id,
+    media_source: mediaSource,
+  }
+  if (pin.title) payload.title = (pin.title as string).substring(0, 100)
+  if (pin.description) payload.description = (pin.description as string).substring(0, 800)
+  if (pin.alt_text) payload.alt_text = (pin.alt_text as string).substring(0, 500)
+  const linkUrl = pin.alternate_url ?? pin.blog_articles?.url
+  if (linkUrl) payload.link = linkUrl
+
+  console.log('\nCreating Pinterest pin...')
+  const result = await pinterestFetch<{ id: string }>(
+    '/pins', token, { method: 'POST', body: JSON.stringify(payload) }
+  )
+  console.log('Pinterest pin created! ID:', result.id)
+
+  // 9. Update pin record
+  await supabase
+    .from('pins')
+    .update({
+      status: 'published',
+      published_at: new Date().toISOString(),
+      pinterest_pin_id: result.id,
+      pinterest_pin_url: `https://www.pinterest.com/pin/${result.id}/`,
+    })
+    .eq('id', TARGET_PIN_ID)
+
+  console.log(`\n✓ Pin published successfully!`)
+  console.log(`  Pinterest URL: https://www.pinterest.com/pin/${result.id}/`)
+  console.log(`  DB status: published`)
+}
+
+main().catch(err => {
+  console.error('\nFatal error:', err.message ?? err)
+  process.exit(1)
+})

--- a/src/components/calendar/pin-sidebar.tsx
+++ b/src/components/calendar/pin-sidebar.tsx
@@ -277,6 +277,7 @@ function PinSidebarForm({
           hasPinterestConnection={connectionData?.connected ?? false}
           hasPinterestBoard={!!pin.pinterest_board_id}
           pinterestPinUrl={pin.pinterest_pin_url}
+          mediaType={pin.media_type ?? 'image'}
         />
       </div>
 

--- a/src/components/pins/edit-pin-dialog.tsx
+++ b/src/components/pins/edit-pin-dialog.tsx
@@ -54,6 +54,7 @@ const editPinSchema = z.object({
   alternate_url: z.string().url('Ungültige URL').or(z.literal('')).optional(),
   pinterest_board_id: z.string(),
   status: z.string(),
+  cover_keyframe_seconds: z.number().int().min(0).optional(),
 })
 
 type EditPinFormData = z.infer<typeof editPinSchema>
@@ -82,6 +83,7 @@ export function EditPinDialog({ open, onOpenChange, pin, projectId }: EditPinDia
       alternate_url: '',
       pinterest_board_id: '',
       status: 'draft',
+      cover_keyframe_seconds: 1,
     },
   })
 
@@ -107,6 +109,7 @@ export function EditPinDialog({ open, onOpenChange, pin, projectId }: EditPinDia
         alternate_url: pin.alternate_url || '',
         pinterest_board_id: pin.pinterest_board_id || '__none__',
         status: pin.status,
+        cover_keyframe_seconds: pin.cover_keyframe_seconds ?? 1,
       })
     }
   }, [open, pin, reset])
@@ -125,6 +128,9 @@ export function EditPinDialog({ open, onOpenChange, pin, projectId }: EditPinDia
         pinterest_board_id: selectedBoard?.pinterest_board_id || null,
         pinterest_board_name: selectedBoard?.name || null,
         status: data.status as PinStatus,
+        ...(pin.media_type === 'video' && {
+          cover_keyframe_seconds: data.cover_keyframe_seconds ?? 1,
+        }),
       })
       onOpenChange(false)
     } catch (error) {
@@ -201,6 +207,24 @@ export function EditPinDialog({ open, onOpenChange, pin, projectId }: EditPinDia
               <p className="text-sm text-red-600">{errors.alternate_url.message}</p>
             )}
           </div>
+
+          {pin.media_type === 'video' && (
+            <div className="space-y-2">
+              <Label htmlFor="edit-cover-keyframe">{t('editPin.fieldCoverKeyframe')}</Label>
+              <Input
+                id="edit-cover-keyframe"
+                type="number"
+                min={0}
+                {...register('cover_keyframe_seconds', { valueAsNumber: true })}
+                placeholder={t('editPin.placeholderCoverKeyframe')}
+                disabled={isSubmitting}
+              />
+              <p className="text-xs text-slate-500">{t('editPin.helpCoverKeyframe')}</p>
+              {errors.cover_keyframe_seconds && (
+                <p className="text-sm text-red-600">{errors.cover_keyframe_seconds.message}</p>
+              )}
+            </div>
+          )}
 
           <div className="space-y-2">
             <Label htmlFor="edit-board">{t('editPin.fieldBoard')}</Label>

--- a/src/components/pins/publish-pin-button.tsx
+++ b/src/components/pins/publish-pin-button.tsx
@@ -18,6 +18,7 @@ interface PublishPinButtonProps {
   hasPinterestConnection: boolean
   hasPinterestBoard: boolean
   pinterestPinUrl?: string | null
+  mediaType?: 'image' | 'video'
   variant?: 'default' | 'outline' | 'ghost'
   size?: 'default' | 'sm'
 }
@@ -28,6 +29,7 @@ export function PublishPinButton({
   hasPinterestConnection,
   hasPinterestBoard,
   pinterestPinUrl,
+  mediaType = 'image',
   variant = 'outline',
   size = 'sm',
 }: PublishPinButtonProps) {
@@ -71,7 +73,9 @@ export function PublishPinButton({
         className="border-red-300 text-red-600 hover:bg-red-50"
       >
         <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
-        {publishMutation.isPending ? t('publishPin.retrying') : t('publishPin.retryPublish')}
+        {publishMutation.isPending
+          ? t(mediaType === 'video' ? 'publishPin.retryingVideo' : 'publishPin.retrying')
+          : t('publishPin.retryPublish')}
       </Button>
     )
   }
@@ -127,7 +131,9 @@ export function PublishPinButton({
       disabled={publishMutation.isPending}
     >
       <Send className="mr-1.5 h-3.5 w-3.5" />
-      {publishMutation.isPending ? t('publishPin.publishing') : t('publishPin.publish')}
+      {publishMutation.isPending
+        ? t(mediaType === 'video' ? 'publishPin.publishingVideo' : 'publishPin.publishing')
+        : t('publishPin.publish')}
     </Button>
   )
 }

--- a/src/lib/gemini/client.ts
+++ b/src/lib/gemini/client.ts
@@ -135,13 +135,14 @@ export async function generatePinMetadata(
   pinImageUrl: string,
   systemPrompt: string | undefined,
   apiKey: string,
-  mediaType: 'image' | 'video' = 'image'
+  mediaType: 'image' | 'video' = 'image',
+  inlineImageData?: { data: string; mimeType: string }
 ): Promise<GeneratedMetadata> {
   const articleSection = articleTitle
     ? `\n\nArticle Title: ${articleTitle}\n\nArticle Content: ${(articleContent ?? '').slice(0, 4000)}`
     : `\n\n[No article linked — generate metadata based solely on the image.]`
   const promptText = `Pin Type: ${mediaType === 'video' ? 'Video' : 'Image'}${articleSection}`
-  const imageData = await fetchImageAsBase64(pinImageUrl)
+  const imageData = inlineImageData ?? await fetchImageAsBase64(pinImageUrl)
 
   const response = await getAiClient(apiKey).models.generateContent({
     model: 'gemini-2.5-flash',
@@ -182,13 +183,14 @@ export async function generatePinMetadataWithFeedback(
   feedback: string,
   apiKey: string,
   mediaType: 'image' | 'video' = 'image',
-  systemPrompt?: string
+  systemPrompt?: string,
+  inlineImageData?: { data: string; mimeType: string }
 ): Promise<GeneratedMetadata> {
   const articleSection = articleTitle
     ? `\n\nArticle Title: ${articleTitle}\n\nArticle Content: ${(articleContent ?? '').slice(0, 4000)}`
     : `\n\n[No article linked — generate metadata based solely on the image.]`
   const promptText = `Pin Type: ${mediaType === 'video' ? 'Video' : 'Image'}${articleSection}`
-  const imageData = await fetchImageAsBase64(pinImageUrl)
+  const imageData = inlineImageData ?? await fetchImageAsBase64(pinImageUrl)
 
   const chat = getAiClient(apiKey).chats.create({
     model: 'gemini-2.5-flash',

--- a/src/lib/server/ffmpeg-client.test.ts
+++ b/src/lib/server/ffmpeg-client.test.ts
@@ -1,0 +1,155 @@
+import { extractKeyframe } from './ffmpeg-client'
+
+const originalEnv = { ...process.env }
+
+beforeEach(() => {
+  process.env.FFMPEG_SERVER_URL = 'https://util.weissteiner-automation.com'
+  process.env.FFMPEG_SERVER_TOKEN = 'test-token'
+})
+
+afterEach(() => {
+  process.env = { ...originalEnv }
+  vi.restoreAllMocks()
+})
+
+// Build an "image" Response that mimics the ffmpeg server's /thumbnail output.
+function imageResponse(
+  bytes: Uint8Array,
+  contentType: 'image/jpeg' | 'image/png' = 'image/jpeg',
+) {
+  return new Response(bytes, {
+    status: 200,
+    headers: { 'Content-Type': contentType },
+  })
+}
+
+describe('extractKeyframe', () => {
+  it('POSTs JSON to /thumbnail with bearer auth and returns image bytes', async () => {
+    const mockBytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]) // JPEG magic
+    const fetchSpy = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(imageResponse(mockBytes))
+
+    const result = await extractKeyframe('https://cdn.example.com/video.mp4')
+
+    expect(result.contentType).toBe('image/jpeg')
+    expect(Array.from(result.bytes)).toEqual(Array.from(mockBytes))
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('https://util.weissteiner-automation.com/thumbnail')
+    expect(init.method).toBe('POST')
+    const headers = init.headers as Record<string, string>
+    expect(headers.Authorization).toBe('Bearer test-token')
+    expect(headers['Content-Type']).toBe('application/json')
+    expect(headers.Accept).toBe('image/jpeg')
+    expect(JSON.parse(init.body as string)).toEqual({
+      url: 'https://cdn.example.com/video.mp4',
+      second: 1,
+      format: 'jpeg',
+    })
+  })
+
+  it('uses provided options (second, format, quality)', async () => {
+    const fetchSpy = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(imageResponse(new Uint8Array([0x89, 0x50]), 'image/png'))
+
+    await extractKeyframe('https://cdn.example.com/video.mp4', {
+      second: 5,
+      format: 'png',
+      quality: 2,
+    })
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit]
+    const headers = init.headers as Record<string, string>
+    expect(headers.Accept).toBe('image/png')
+    expect(JSON.parse(init.body as string)).toEqual({
+      url: 'https://cdn.example.com/video.mp4',
+      second: 5,
+      format: 'png',
+      quality: 2,
+    })
+  })
+
+  it('strips trailing slash from FFMPEG_SERVER_URL', async () => {
+    process.env.FFMPEG_SERVER_URL = 'https://util.weissteiner-automation.com/'
+    const fetchSpy = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(imageResponse(new Uint8Array([1])))
+
+    await extractKeyframe('https://cdn.example.com/video.mp4')
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://util.weissteiner-automation.com/thumbnail',
+      expect.any(Object),
+    )
+  })
+
+  it('returns image/png when the server responds with PNG bytes', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+      imageResponse(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), 'image/png'),
+    )
+
+    const result = await extractKeyframe('https://cdn.example.com/video.mp4', {
+      format: 'png',
+    })
+    expect(result.contentType).toBe('image/png')
+  })
+
+  it('throws when FFMPEG_SERVER_URL is missing', async () => {
+    delete process.env.FFMPEG_SERVER_URL
+    await expect(extractKeyframe('https://cdn.example.com/v.mp4')).rejects.toThrow(
+      /FFMPEG_SERVER_URL is not configured/,
+    )
+  })
+
+  it('throws when FFMPEG_SERVER_TOKEN is missing', async () => {
+    delete process.env.FFMPEG_SERVER_TOKEN
+    await expect(extractKeyframe('https://cdn.example.com/v.mp4')).rejects.toThrow(
+      /FFMPEG_SERVER_TOKEN is not configured/,
+    )
+  })
+
+  it('throws with the server error code and message on failure', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          success: false,
+          error: { code: 'THUMBNAIL_OUT_OF_RANGE', message: 'beyond end of video' },
+        }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+
+    await expect(
+      extractKeyframe('https://cdn.example.com/v.mp4', { second: 99999 }),
+    ).rejects.toThrow(/THUMBNAIL_OUT_OF_RANGE: beyond end of video/)
+  })
+
+  it('falls back to status line when error body is not JSON', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+      new Response('<html>500</html>', {
+        status: 500,
+        statusText: 'Internal Server Error',
+      }),
+    )
+
+    await expect(
+      extractKeyframe('https://cdn.example.com/v.mp4'),
+    ).rejects.toThrow(/500 Internal Server Error/)
+  })
+
+  it('throws when the server returns unexpected Content-Type', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+      new Response('not an image', {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+      }),
+    )
+
+    await expect(
+      extractKeyframe('https://cdn.example.com/v.mp4'),
+    ).rejects.toThrow(/unexpected Content-Type: text\/plain/)
+  })
+})

--- a/src/lib/server/ffmpeg-client.ts
+++ b/src/lib/server/ffmpeg-client.ts
@@ -1,0 +1,111 @@
+/**
+ * Client for the external ffmpeg-Docker-API service.
+ *
+ * Used by the video publish flow to extract a cover thumbnail from a video
+ * at a specific second when the user did not upload a manual cover image,
+ * and by the AI metadata generation flow to provide Gemini with a frame from
+ * a video pin.
+ *
+ * The service exposes `POST /thumbnail` (added in the `feat/thumbnail-endpoint`
+ * branch of theaussie86/ffmpeg-Docker-API). Interface spec:
+ *
+ *   Request:
+ *     POST ${FFMPEG_SERVER_URL}/thumbnail
+ *     Authorization: Bearer ${FFMPEG_SERVER_TOKEN}
+ *     Content-Type: application/json
+ *     Body: { "url": string, "second"?: number, "format"?: "jpeg"|"png", "quality"?: number }
+ *
+ *   Response (success):
+ *     200 OK, body = raw image bytes, Content-Type: image/jpeg | image/png
+ *
+ *   Response (failure):
+ *     400/413/422 with JSON envelope:
+ *     { success: false, error: { code, message, correlationId } }
+ */
+
+export interface KeyframeOptions {
+  /** Timestamp in seconds (default: 1) */
+  second?: number
+  /** Output image format (default: 'jpeg') */
+  format?: 'jpeg' | 'png'
+  /** JPEG quality 2-31, lower = better (default: 3) */
+  quality?: number
+}
+
+export interface KeyframeResult {
+  bytes: Uint8Array
+  contentType: 'image/jpeg' | 'image/png'
+}
+
+function getFfmpegConfig(): { baseUrl: string; token: string } {
+  const baseUrl = process.env.FFMPEG_SERVER_URL
+  const token = process.env.FFMPEG_SERVER_TOKEN
+  if (!baseUrl) {
+    throw new Error('FFMPEG_SERVER_URL is not configured')
+  }
+  if (!token) {
+    throw new Error('FFMPEG_SERVER_TOKEN is not configured')
+  }
+  return { baseUrl: baseUrl.replace(/\/$/, ''), token }
+}
+
+/**
+ * Ask the ffmpeg server to extract a single frame from `videoUrl` at the
+ * given timestamp and return the image bytes.
+ *
+ * Throws a descriptive error with the server's error code/message on failure.
+ */
+export async function extractKeyframe(
+  videoUrl: string,
+  options: KeyframeOptions = {},
+): Promise<KeyframeResult> {
+  const { baseUrl, token } = getFfmpegConfig()
+  const second = options.second ?? 1
+  const format = options.format ?? 'jpeg'
+  const body: Record<string, unknown> = {
+    url: videoUrl,
+    second,
+    format,
+  }
+  if (options.quality !== undefined) {
+    body.quality = options.quality
+  }
+
+  const response = await fetch(`${baseUrl}/thumbnail`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: format === 'png' ? 'image/png' : 'image/jpeg',
+    },
+    body: JSON.stringify(body),
+  })
+
+  if (!response.ok) {
+    let detail = `${response.status} ${response.statusText}`
+    try {
+      const errJson = (await response.json()) as {
+        error?: { code?: string; message?: string }
+      }
+      if (errJson?.error?.message) {
+        detail = `${errJson.error.code ?? 'error'}: ${errJson.error.message}`
+      }
+    } catch {
+      // Body wasn't JSON — keep the status line as detail.
+    }
+    throw new Error(`ffmpeg server /thumbnail failed — ${detail}`)
+  }
+
+  const contentType = response.headers.get('content-type') ?? ''
+  if (!contentType.startsWith('image/')) {
+    throw new Error(
+      `ffmpeg server returned unexpected Content-Type: ${contentType || '(none)'}`,
+    )
+  }
+
+  const arrayBuffer = await response.arrayBuffer()
+  return {
+    bytes: new Uint8Array(arrayBuffer),
+    contentType: contentType.startsWith('image/png') ? 'image/png' : 'image/jpeg',
+  }
+}

--- a/src/lib/server/metadata.test.ts
+++ b/src/lib/server/metadata.test.ts
@@ -1,7 +1,7 @@
 import { generateMetadataFn, generateMetadataWithFeedbackFn, triggerBulkMetadataFn } from './metadata'
 import { createMockQueryBuilder } from '@/test/mocks/supabase'
 
-const { mockServerClient, mockServiceClient, mockGenerateMetadata, mockGenerateWithFeedback, mockGetVaultKey } =
+const { mockServerClient, mockServiceClient, mockGenerateMetadata, mockGenerateWithFeedback, mockGetVaultKey, mockExtractKeyframe } =
   vi.hoisted(() => ({
     mockServerClient: {
       from: vi.fn(),
@@ -27,6 +27,7 @@ const { mockServerClient, mockServiceClient, mockGenerateMetadata, mockGenerateW
       alt_text: 'Feedback alt',
     }),
     mockGetVaultKey: vi.fn().mockResolvedValue('test-gemini-api-key'),
+    mockExtractKeyframe: vi.fn().mockResolvedValue({ bytes: new Uint8Array([1, 2, 3]), contentType: 'image/jpeg' }),
   }))
 
 vi.mock('@tanstack/react-start', () => ({
@@ -45,6 +46,10 @@ vi.mock('./supabase', () => ({
 vi.mock('@/lib/gemini/client', () => ({
   generatePinMetadata: (...args: any[]) => mockGenerateMetadata(...args),
   generatePinMetadataWithFeedback: (...args: any[]) => mockGenerateWithFeedback(...args),
+}))
+
+vi.mock('./ffmpeg-client', () => ({
+  extractKeyframe: (...args: any[]) => mockExtractKeyframe(...args),
 }))
 
 vi.mock('../../../server/lib/vault-helpers', () => ({
@@ -126,6 +131,7 @@ describe('generateMetadataFn', () => {
       expect.any(String),
       'test-gemini-api-key',
       'image',
+      undefined,
     )
 
     // Verify API key was fetched from vault
@@ -197,6 +203,7 @@ describe('generateMetadataFn', () => {
       expect.any(String),
       'test-gemini-api-key',
       'image',
+      undefined,
     )
     // API key fetched using pin.blog_project_id directly
     expect(mockGetVaultKey).toHaveBeenCalledWith(mockServiceClient, 'proj-1')
@@ -268,6 +275,7 @@ describe('generateMetadataWithFeedbackFn', () => {
       'test-gemini-api-key',
       'image',
       expect.any(String),
+      undefined,
     )
 
     // Verify new generation was stored with feedback text
@@ -309,6 +317,7 @@ describe('generateMetadataWithFeedbackFn', () => {
       'test-gemini-api-key',
       'image',
       expect.any(String),
+      undefined,
     )
   })
 

--- a/src/lib/server/metadata.ts
+++ b/src/lib/server/metadata.ts
@@ -2,6 +2,7 @@ import { createServerFn } from '@tanstack/react-start'
 import { tasks } from '@trigger.dev/sdk/v3'
 import { getSupabaseServerClient, getSupabaseServiceClient } from './supabase'
 import { generatePinMetadata, generatePinMetadataWithFeedback } from '@/lib/gemini/client'
+import { extractKeyframe } from '@/lib/server/ffmpeg-client'
 import { getGeminiApiKeyFromVault } from '../../../server/lib/vault-helpers'
 import { sanitizeLanguage } from '@/lib/gemini/language'
 import { buildPinterestSeoSystemPrompt } from '@/lib/gemini/prompts'
@@ -67,6 +68,16 @@ export const generateMetadataFn = createServerFn({ method: 'POST' })
       const ext = pin.image_path.split('.').pop()?.toLowerCase() ?? ''
       const mediaType = ['mp4', 'mov', 'avi', 'webm'].includes(ext) ? 'video' : 'image'
 
+      // For video pins: extract a keyframe and pass it to Gemini instead of the raw video
+      let inlineImageData: { data: string; mimeType: string } | undefined
+      if (mediaType === 'video') {
+        const keyframe = await extractKeyframe(imageUrl, { second: pin.cover_keyframe_seconds ?? 1 })
+        inlineImageData = {
+          data: Buffer.from(keyframe.bytes).toString('base64'),
+          mimeType: keyframe.contentType,
+        }
+      }
+
       // Call Gemini to generate metadata (article may be null)
       const metadata = await generatePinMetadata(
         pin.blog_articles?.title ?? null,
@@ -74,7 +85,8 @@ export const generateMetadataFn = createServerFn({ method: 'POST' })
         imageUrl,
         systemPrompt,
         apiKey,
-        mediaType
+        mediaType,
+        inlineImageData
       )
 
       // Insert into pin_metadata_generations table
@@ -197,6 +209,16 @@ export const generateMetadataWithFeedbackFn = createServerFn({ method: 'POST' })
       const ext = pin.image_path.split('.').pop()?.toLowerCase() ?? ''
       const mediaType = ['mp4', 'mov', 'avi', 'webm'].includes(ext) ? 'video' : 'image'
 
+      // For video pins: extract a keyframe and pass it to Gemini instead of the raw video
+      let inlineImageData: { data: string; mimeType: string } | undefined
+      if (mediaType === 'video') {
+        const keyframe = await extractKeyframe(imageUrl, { second: pin.cover_keyframe_seconds ?? 1 })
+        inlineImageData = {
+          data: Buffer.from(keyframe.bytes).toString('base64'),
+          mimeType: keyframe.contentType,
+        }
+      }
+
       // Call Gemini with feedback (multi-turn conversation, article may be null)
       const metadata = await generatePinMetadataWithFeedback(
         pin.blog_articles?.title ?? null,
@@ -210,7 +232,8 @@ export const generateMetadataWithFeedbackFn = createServerFn({ method: 'POST' })
         data.feedback,
         apiKey,
         mediaType,
-        systemPrompt
+        systemPrompt,
+        inlineImageData
       )
 
       // Store new generation in pin_metadata_generations WITH feedback text

--- a/src/lib/server/pinterest-api.test.ts
+++ b/src/lib/server/pinterest-api.test.ts
@@ -7,7 +7,12 @@ import {
   generateCodeVerifier,
   generateCodeChallenge,
   generateState,
+  registerPinterestMedia,
+  uploadVideoToPinterestS3,
+  getPinterestMediaStatus,
+  waitForPinterestMediaReady,
 } from './pinterest-api'
+import type { PinterestMediaRegisterResponse } from '@/types/pinterest'
 
 // Store original env
 const originalEnv = { ...process.env }
@@ -373,5 +378,205 @@ describe('generateState', () => {
     const a = generateState()
     const b = generateState()
     expect(a).not.toBe(b)
+  })
+})
+
+// ─── Video upload flow ───────────────────────────────────────────
+
+describe('registerPinterestMedia', () => {
+  it('POSTs media_type=video and returns media_id + upload info', async () => {
+    const mockResponse = {
+      media_id: 'media-123',
+      media_type: 'video',
+      upload_url: 'https://pinterest-media-upload.s3-accelerate.amazonaws.com/',
+      upload_parameters: {
+        key: 'uploads/abc',
+        policy: 'signed-policy',
+        'x-amz-signature': 'sig',
+      },
+    }
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify(mockResponse), { status: 200 }),
+    )
+
+    const result = await registerPinterestMedia('access-token-xyz')
+
+    expect(result).toEqual(mockResponse)
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.pinterest.com/v5/media',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ media_type: 'video' }),
+      }),
+    )
+    const call = fetchSpy.mock.calls[0]!
+    const init = call[1] as RequestInit
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      'Bearer access-token-xyz',
+    )
+  })
+
+  it('throws when Pinterest returns an error', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: 'nope' }), { status: 500 }),
+    )
+    await expect(registerPinterestMedia('token')).rejects.toThrow(
+      'Pinterest API error: nope',
+    )
+  })
+})
+
+describe('uploadVideoToPinterestS3', () => {
+  const register: PinterestMediaRegisterResponse = {
+    media_id: 'media-42',
+    media_type: 'video',
+    upload_url: 'https://pinterest-media-upload.s3-accelerate.amazonaws.com/',
+    upload_parameters: {
+      key: 'uploads/xy',
+      policy: 'sig-policy',
+      'x-amz-signature': 'sig-abc',
+      'x-amz-date': '20260408T000000Z',
+    },
+  }
+
+  it('sends all upload_parameters as form fields followed by the file', async () => {
+    const fetchSpy = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+
+    const bytes = new Uint8Array([0x00, 0x01, 0x02, 0x03])
+    await uploadVideoToPinterestS3(register, bytes, 'pin.mp4')
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(register.upload_url)
+    expect(init.method).toBe('POST')
+
+    // Body must be FormData with all parameters and the file field last.
+    const body = init.body as FormData
+    expect(body).toBeInstanceOf(FormData)
+    const keys = Array.from(body.keys())
+    expect(keys).toContain('key')
+    expect(keys).toContain('policy')
+    expect(keys).toContain('x-amz-signature')
+    expect(keys).toContain('x-amz-date')
+    expect(keys[keys.length - 1]).toBe('file')
+    expect(body.get('key')).toBe('uploads/xy')
+    expect(body.get('policy')).toBe('sig-policy')
+    const file = body.get('file') as File
+    expect(file).toBeInstanceOf(File)
+    expect(file.name).toBe('pin.mp4')
+  })
+
+  it('throws when S3 rejects the upload', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+      new Response('<Error>AccessDenied</Error>', {
+        status: 403,
+        statusText: 'Forbidden',
+      }),
+    )
+    await expect(
+      uploadVideoToPinterestS3(register, new Uint8Array([1, 2]), 'p.mp4'),
+    ).rejects.toThrow(/Pinterest S3 upload failed: 403/)
+  })
+})
+
+describe('getPinterestMediaStatus', () => {
+  it('GETs /media/{id} with bearer auth', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          media_id: 'm1',
+          media_type: 'video',
+          status: 'succeeded',
+        }),
+        { status: 200 },
+      ),
+    )
+
+    const result = await getPinterestMediaStatus('tok', 'm1')
+    expect(result.status).toBe('succeeded')
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.pinterest.com/v5/media/m1',
+      expect.objectContaining({ method: 'GET' }),
+    )
+  })
+
+  it('url-encodes the media id', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          media_id: 'a/b',
+          media_type: 'video',
+          status: 'succeeded',
+        }),
+        { status: 200 },
+      ),
+    )
+    await getPinterestMediaStatus('tok', 'a/b')
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.pinterest.com/v5/media/a%2Fb',
+      expect.objectContaining({ method: 'GET' }),
+    )
+  })
+})
+
+describe('waitForPinterestMediaReady', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const responseFor = (status: string) =>
+    new Response(
+      JSON.stringify({ media_id: 'm', media_type: 'video', status }),
+      { status: 200 },
+    )
+
+  it('returns when status becomes succeeded on first poll', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce(responseFor('succeeded'))
+
+    const result = await waitForPinterestMediaReady('tok', 'm')
+    expect(result.status).toBe('succeeded')
+  })
+
+  it('polls with backoff until succeeded', async () => {
+    vi.spyOn(global, 'fetch')
+      .mockResolvedValueOnce(responseFor('registered'))
+      .mockResolvedValueOnce(responseFor('processing'))
+      .mockResolvedValueOnce(responseFor('succeeded'))
+
+    const promise = waitForPinterestMediaReady('tok', 'm')
+    // Advance enough to cover the first two backoff steps (5s + 10s).
+    await vi.advanceTimersByTimeAsync(16_000)
+    const result = await promise
+    expect(result.status).toBe('succeeded')
+    expect(global.fetch).toHaveBeenCalledTimes(3)
+  })
+
+  it('throws when Pinterest reports failed', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce(responseFor('failed'))
+    await expect(waitForPinterestMediaReady('tok', 'm-failed')).rejects.toThrow(
+      /failed for media_id=m-failed/,
+    )
+  })
+
+  it('throws when the deadline is exceeded before succeeded', async () => {
+    // Return a *fresh* Response each call — a single Response can only be
+    // read once, so mockResolvedValue would reuse an already-drained body.
+    vi.spyOn(global, 'fetch').mockImplementation(() =>
+      Promise.resolve(responseFor('processing')),
+    )
+
+    const promise = waitForPinterestMediaReady('tok', 'm', {
+      timeoutMs: 20_000,
+    })
+    const assertion = expect(promise).rejects.toThrow(
+      /did not reach 'succeeded' within 20000ms/,
+    )
+    await vi.advanceTimersByTimeAsync(120_000)
+    await assertion
   })
 })

--- a/src/lib/server/pinterest-api.ts
+++ b/src/lib/server/pinterest-api.ts
@@ -6,6 +6,8 @@ import type {
   PinterestBoardsListResponse,
   PinterestPinResponse,
   PinterestCreatePinPayload,
+  PinterestMediaRegisterResponse,
+  PinterestMediaStatusResponse,
 } from '@/types/pinterest'
 
 const PINTEREST_API_BASE = 'https://api.pinterest.com/v5'
@@ -243,6 +245,120 @@ export async function createPinterestPin(
 
   // Should never reach here, but TypeScript needs this
   throw new Error('Unexpected error in createPinterestPin')
+}
+
+/**
+ * Register a video upload with Pinterest (step 1 of the video publish flow).
+ *
+ * Returns a one-time-use `media_id` plus the signed S3 URL and parameters
+ * needed to upload the actual video bytes. The upload parameters include
+ * short-lived AWS credentials — the upload must happen within a few minutes.
+ */
+export async function registerPinterestMedia(
+  accessToken: string,
+): Promise<PinterestMediaRegisterResponse> {
+  return pinterestFetch<PinterestMediaRegisterResponse>('/media', accessToken, {
+    method: 'POST',
+    body: JSON.stringify({ media_type: 'video' }),
+  })
+}
+
+/**
+ * Upload video bytes to Pinterest's S3 bucket (step 2 of the video publish flow).
+ *
+ * Pinterest returns a signed POST policy in `upload_parameters` that we must
+ * send as multipart/form-data to `upload_url`. All key/value pairs from
+ * `upload_parameters` go first, then the file itself as the `file` field —
+ * S3 signed POST requires this exact field order.
+ */
+export async function uploadVideoToPinterestS3(
+  register: PinterestMediaRegisterResponse,
+  videoBytes: Uint8Array,
+  filename: string,
+  contentType = 'video/mp4',
+): Promise<void> {
+  const form = new FormData()
+
+  // Append signed-POST parameters first (order matters for S3)
+  for (const [key, value] of Object.entries(register.upload_parameters)) {
+    form.append(key, value)
+  }
+
+  // The `file` field must come last and must contain the raw bytes.
+  const blob = new Blob([videoBytes as BlobPart], { type: contentType })
+  form.append('file', blob, filename)
+
+  const response = await fetch(register.upload_url, {
+    method: 'POST',
+    body: form,
+  })
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '')
+    throw new Error(
+      `Pinterest S3 upload failed: ${response.status} ${response.statusText}${
+        errorText ? ` — ${errorText.slice(0, 300)}` : ''
+      }`,
+    )
+  }
+}
+
+/**
+ * Get the processing status of a registered Pinterest media upload (step 3).
+ */
+export async function getPinterestMediaStatus(
+  accessToken: string,
+  mediaId: string,
+): Promise<PinterestMediaStatusResponse> {
+  return pinterestFetch<PinterestMediaStatusResponse>(
+    `/media/${encodeURIComponent(mediaId)}`,
+    accessToken,
+    { method: 'GET' },
+  )
+}
+
+/**
+ * Poll GET /v5/media/{id} until Pinterest reports the upload as `succeeded`.
+ *
+ * Throws if the status becomes `failed` or if the poll loop exceeds the
+ * timeout. Backoff steps (in milliseconds): 5s, 10s, 15s, 30s, 30s, 30s, ...
+ * Total default timeout: 5 minutes, which covers realistic MP4 processing
+ * times for pin-sized clips (<= ~50 MB).
+ */
+export async function waitForPinterestMediaReady(
+  accessToken: string,
+  mediaId: string,
+  options: { timeoutMs?: number; signal?: AbortSignal } = {},
+): Promise<PinterestMediaStatusResponse> {
+  const timeoutMs = options.timeoutMs ?? 5 * 60 * 1000
+  const deadline = Date.now() + timeoutMs
+  const backoffSequenceMs = [5_000, 10_000, 15_000, 30_000]
+  let step = 0
+
+  while (true) {
+    if (options.signal?.aborted) {
+      throw new Error('waitForPinterestMediaReady aborted')
+    }
+
+    const status = await getPinterestMediaStatus(accessToken, mediaId)
+
+    if (status.status === 'succeeded') {
+      return status
+    }
+    if (status.status === 'failed') {
+      throw new Error(`Pinterest media upload failed for media_id=${mediaId}`)
+    }
+
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Pinterest media upload did not reach 'succeeded' within ${timeoutMs}ms (last status: ${status.status})`,
+      )
+    }
+
+    const delay = backoffSequenceMs[Math.min(step, backoffSequenceMs.length - 1)]!
+    step++
+    await new Promise((resolve) => setTimeout(resolve, delay))
+  }
 }
 
 /**

--- a/src/lib/server/pinterest-publishing.ts
+++ b/src/lib/server/pinterest-publishing.ts
@@ -1,8 +1,13 @@
 import { createServerFn } from '@tanstack/react-start'
 import { getSupabaseServerClient, getSupabaseServiceClient } from './supabase'
-import { createPinterestPin } from './pinterest-api'
+import {
+  createPinterestPin,
+  registerPinterestMedia,
+  uploadVideoToPinterestS3,
+  waitForPinterestMediaReady,
+} from './pinterest-api'
 import { notifyPinError } from './notifications'
-import type { PinterestCreatePinPayload } from '@/types/pinterest'
+import type { PinterestCreatePinPayload, PinterestMediaSource } from '@/types/pinterest'
 
 interface PublishResult {
   success: boolean
@@ -56,16 +61,49 @@ export async function publishSinglePin(
 
     const accessToken = tokenData as string
 
-    // Get public URL for pin image
-    const imagePublicUrl = `${process.env.SUPABASE_URL}/storage/v1/object/public/pin-images/${pin.image_path}`
+    const mediaPublicUrl = `${process.env.SUPABASE_URL}/storage/v1/object/public/pin-images/${pin.image_path}`
+
+    let mediaSource: PinterestMediaSource
+
+    if (pin.media_type === 'video') {
+      // Step 1: Register a media slot with Pinterest
+      const registration = await registerPinterestMedia(accessToken)
+
+      // Step 2: Fetch video bytes from Supabase Storage
+      const videoResponse = await fetch(mediaPublicUrl)
+      if (!videoResponse.ok) {
+        throw new Error(
+          `Failed to fetch video from storage: ${videoResponse.status} ${videoResponse.statusText}`,
+        )
+      }
+      const videoBytes = new Uint8Array(await videoResponse.arrayBuffer())
+      const filename = pin.image_path!.split('/').pop() ?? 'video.mp4'
+
+      // Step 3: Upload bytes to Pinterest's S3
+      await uploadVideoToPinterestS3(registration, videoBytes, filename)
+
+      // Step 4: Poll until Pinterest finishes processing
+      await waitForPinterestMediaReady(accessToken, registration.media_id)
+
+      // Step 5: Build video source with cover
+      const videoSource: Extract<PinterestMediaSource, { source_type: 'video_id' }> = {
+        source_type: 'video_id',
+        media_id: registration.media_id,
+      }
+      if (pin.cover_image_path) {
+        videoSource.cover_image_url = `${process.env.SUPABASE_URL}/storage/v1/object/public/pin-images/${pin.cover_image_path}`
+      } else {
+        videoSource.cover_image_key_frame_time = pin.cover_keyframe_seconds ?? 1
+      }
+      mediaSource = videoSource
+    } else {
+      mediaSource = { source_type: 'image_url', url: mediaPublicUrl }
+    }
 
     // Build Pinterest API payload
     const payload: PinterestCreatePinPayload = {
       board_id: pin.pinterest_board_id,
-      media_source: {
-        source_type: 'image_url',
-        url: imagePublicUrl,
-      },
+      media_source: mediaSource,
     }
 
     // Add optional fields (with length limits)

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -16,7 +16,8 @@
     "goHome": "Startseite",
     "untitled": "Ohne Titel",
     "notAssigned": "Nicht zugewiesen",
-    "empty": "Nicht gesetzt"
+    "empty": "Nicht gesetzt",
+    "customImage": "Eigenes Bild"
   },
   "meta": {
     "title": "Pinfinity",
@@ -337,7 +338,10 @@
     "validationAltTextTooLong": "Alternativtext zu lang",
     "pinterestNotConnected": "Pinterest ist nicht verknüpft. Verbinde Pinterest in den Projekteinstellungen, um ein Board auszuwählen.",
     "searchBoard": "Boards suchen...",
-    "noBoardsFound": "Keine Boards gefunden."
+    "noBoardsFound": "Keine Boards gefunden.",
+    "fieldCoverKeyframe": "Cover-Keyframe (Sekunden)",
+    "placeholderCoverKeyframe": "1",
+    "helpCoverKeyframe": "Pinterest extrahiert das Cover-Bild aus dieser Sekunde des Videos."
   },
   "imageUpload": {
     "dropMessage": "Dateien hier ablegen oder ",
@@ -502,6 +506,7 @@
     "unknownError": "Ein unbekannter Fehler ist aufgetreten.",
     "resetStatus": "Status zurücksetzen",
     "resetting": "Zurücksetzen...",
+    "coverKeyframe": "Cover-Keyframe",
     "scheduledAt": "Geplant"
   },
   "articleDetail": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -390,7 +390,9 @@
   "publishPin": {
     "published": "Veröffentlicht",
     "publishing": "Veröffentlichen...",
+    "publishingVideo": "Video wird hochgeladen...",
     "retrying": "Erneut versuchen...",
+    "retryingVideo": "Video wird hochgeladen...",
     "retryGenerate": "Erneut generieren",
     "retryPublish": "Erneut veröffentlichen",
     "publish": "Veröffentlichen",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -16,7 +16,8 @@
     "goHome": "Go home",
     "untitled": "Untitled",
     "notAssigned": "Not assigned",
-    "empty": "Not set"
+    "empty": "Not set",
+    "customImage": "Custom image"
   },
   "meta": {
     "title": "Pinfinity",
@@ -337,7 +338,10 @@
     "validationAltTextTooLong": "Alt text too long",
     "pinterestNotConnected": "Pinterest is not connected. Connect Pinterest in the project settings to select a board.",
     "searchBoard": "Search boards...",
-    "noBoardsFound": "No boards found."
+    "noBoardsFound": "No boards found.",
+    "fieldCoverKeyframe": "Cover Keyframe (seconds)",
+    "placeholderCoverKeyframe": "1",
+    "helpCoverKeyframe": "Pinterest extracts the cover thumbnail from this second of the video."
   },
   "imageUpload": {
     "dropMessage": "Drop files here or ",
@@ -502,6 +506,7 @@
     "unknownError": "An unknown error occurred.",
     "resetStatus": "Reset Status",
     "resetting": "Resetting...",
+    "coverKeyframe": "Cover Keyframe",
     "scheduledAt": "Scheduled"
   },
   "articleDetail": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -390,7 +390,9 @@
   "publishPin": {
     "published": "Published",
     "publishing": "Publishing...",
+    "publishingVideo": "Uploading video...",
     "retrying": "Retrying...",
+    "retryingVideo": "Uploading video...",
     "retryGenerate": "Retry generation",
     "retryPublish": "Retry Publish",
     "publish": "Publish",

--- a/src/routes/_authed/projects/$projectId/pins/$pinId.tsx
+++ b/src/routes/_authed/projects/$projectId/pins/$pinId.tsx
@@ -187,6 +187,7 @@ function PinDetail() {
                     hasPinterestConnection={connectionData?.connected ?? false}
                     hasPinterestBoard={!!pin.pinterest_board_id}
                     pinterestPinUrl={pin.pinterest_pin_url}
+                    mediaType={pin.media_type ?? 'image'}
                   />
                   {pin.pinterest_pin_url && (
                     <a

--- a/src/routes/_authed/projects/$projectId/pins/$pinId.tsx
+++ b/src/routes/_authed/projects/$projectId/pins/$pinId.tsx
@@ -124,6 +124,19 @@ function PinDetail() {
                       </p>
                     </div>
 
+                    {/* Video cover keyframe (video pins only) */}
+                    {pin.media_type === 'video' && (
+                      <div>
+                        <h3 className="text-xs font-medium text-slate-500 uppercase mb-1">{t('pinDetail.coverKeyframe')}</h3>
+                        <p className="text-sm text-slate-700">
+                          {pin.cover_image_path
+                            ? <span className="text-blue-600">{t('common.customImage')}</span>
+                            : `${pin.cover_keyframe_seconds ?? 1}s`
+                          }
+                        </p>
+                      </div>
+                    )}
+
                     {/* Andere URL */}
                     <div>
                       <h3 className="text-xs font-medium text-slate-500 uppercase mb-1">{t('pinDetail.alternateUrl')}</h3>

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -18,6 +18,8 @@ export function buildPin(overrides: Partial<Pin> = {}): Pin {
     pinterest_board_name: null,
     image_path: `test-tenant-id/${id}.png`,
     media_type: 'image',
+    cover_image_path: null,
+    cover_keyframe_seconds: 1,
     title: 'Test Pin Title',
     description: 'Test pin description',
     alt_text: 'Test alt text',

--- a/src/trigger/generate-metadata.test.ts
+++ b/src/trigger/generate-metadata.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { createMockQueryBuilder } from '@/test/mocks/supabase'
 
 // Use hoisted to define mocks that are accessed during module initialization
-const { mockSupabase, mockGeneratePinMetadata, capturedTaskConfig } = vi.hoisted(() => {
+const { mockSupabase, mockGeneratePinMetadata, mockExtractKeyframe, capturedTaskConfig } = vi.hoisted(() => {
   // Set env vars FIRST before any imports that use them
   process.env.SUPABASE_URL = 'https://test.supabase.co'
   process.env.SUPABASE_SECRET_KEY = 'test-service-key'
@@ -14,6 +14,7 @@ const { mockSupabase, mockGeneratePinMetadata, capturedTaskConfig } = vi.hoisted
       rpc: vi.fn(),
     },
     mockGeneratePinMetadata: vi.fn(),
+    mockExtractKeyframe: vi.fn(),
     capturedTaskConfig: { current: taskConfig },
   }
 })
@@ -24,6 +25,10 @@ vi.mock('@supabase/supabase-js', () => ({
 
 vi.mock('@/lib/gemini/client', () => ({
   generatePinMetadata: (...args: any[]) => mockGeneratePinMetadata(...args),
+}))
+
+vi.mock('@/lib/server/ffmpeg-client', () => ({
+  extractKeyframe: (...args: any[]) => mockExtractKeyframe(...args),
 }))
 
 vi.mock('@/lib/gemini/language', () => ({
@@ -75,6 +80,10 @@ describe('generateMetadataTask', () => {
     vi.clearAllMocks()
     mockGeneratePinMetadata.mockResolvedValue(mockMetadata)
     mockSupabase.rpc.mockResolvedValue({ data: 'test-api-key', error: null })
+    mockExtractKeyframe.mockResolvedValue({
+      bytes: new Uint8Array([1, 2, 3]),
+      contentType: 'image/jpeg',
+    })
   })
 
   describe('task configuration', () => {
@@ -117,7 +126,7 @@ describe('generateMetadataTask', () => {
       // Verify status was set to generating_metadata
       expect(statusUpdateQb.update).toHaveBeenCalledWith({ status: 'generating_metadata' })
 
-      // Verify Gemini was called with correct parameters
+      // Verify Gemini was called with correct parameters (image pin: no inlineImageData)
       expect(mockGeneratePinMetadata).toHaveBeenCalledWith(
         'Article Title',
         'Article Content',
@@ -125,6 +134,7 @@ describe('generateMetadataTask', () => {
         'test-system-prompt',
         'test-api-key',
         'image',
+        undefined,
       )
 
       // Verify pin was updated with metadata and status
@@ -161,6 +171,7 @@ describe('generateMetadataTask', () => {
         expect.anything(),
         expect.anything(),
         expect.anything(),
+        undefined,
       )
     })
 
@@ -189,11 +200,12 @@ describe('generateMetadataTask', () => {
         expect.anything(),
         'test-api-key',
         'image',
+        undefined,
       )
     })
 
-    it('detects video media type from file extension', async () => {
-      const videoPin = { ...mockPin, image_path: 'tenant/video.mp4' }
+    it('detects video media type and extracts keyframe via ffmpeg', async () => {
+      const videoPin = { ...mockPin, image_path: 'tenant/video.mp4', cover_keyframe_seconds: 2 }
       const statusUpdateQb = createMockQueryBuilder({ data: null })
       const pinFetchQb = createMockQueryBuilder({ data: videoPin })
       const projectQb = createMockQueryBuilder({ data: { language: null } })
@@ -211,13 +223,21 @@ describe('generateMetadataTask', () => {
 
       await runTask(payload)
 
+      // Should have called extractKeyframe at the configured second
+      expect(mockExtractKeyframe).toHaveBeenCalledWith(
+        expect.stringContaining('video.mp4'),
+        { second: 2 },
+      )
+
+      // Should pass keyframe data to Gemini, not the raw video
       expect(mockGeneratePinMetadata).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
         expect.anything(),
         expect.anything(),
         expect.anything(),
-        'video', // Should detect video type
+        'video',
+        { data: expect.any(String), mimeType: 'image/jpeg' },
       )
     })
 

--- a/src/trigger/generate-metadata.ts
+++ b/src/trigger/generate-metadata.ts
@@ -1,6 +1,7 @@
 import { task } from '@trigger.dev/sdk/v3'
 import { createClient } from '@supabase/supabase-js'
 import { generatePinMetadata } from '@/lib/gemini/client'
+import { extractKeyframe } from '@/lib/server/ffmpeg-client'
 import { sanitizeLanguage } from '@/lib/gemini/language'
 import { buildPinterestSeoSystemPrompt } from '@/lib/gemini/prompts'
 import { notifyPinError } from '@/lib/server/notifications'
@@ -74,6 +75,16 @@ export const generateMetadataTask = task({
       const ext = pin.image_path.split('.').pop()?.toLowerCase() ?? ''
       const mediaType = ['mp4', 'mov', 'avi', 'webm'].includes(ext) ? 'video' : 'image'
 
+      // For video pins: extract a keyframe and pass it to Gemini instead of the raw video
+      let inlineImageData: { data: string; mimeType: string } | undefined
+      if (mediaType === 'video') {
+        const keyframe = await extractKeyframe(imageUrl, { second: pin.cover_keyframe_seconds ?? 1 })
+        inlineImageData = {
+          data: Buffer.from(keyframe.bytes).toString('base64'),
+          mimeType: keyframe.contentType,
+        }
+      }
+
       // Generate metadata with Gemini
       const metadata = await generatePinMetadata(
         pin.blog_articles?.title ?? null,
@@ -81,7 +92,8 @@ export const generateMetadataTask = task({
         imageUrl,
         systemPrompt,
         apiKey,
-        mediaType
+        mediaType,
+        inlineImageData
       )
 
       // Insert generation history

--- a/src/types/pins.ts
+++ b/src/types/pins.ts
@@ -33,6 +33,8 @@ export interface Pin {
   pinterest_board_name: string | null
   image_path: string | null
   media_type: 'image' | 'video'
+  cover_image_path: string | null
+  cover_keyframe_seconds: number | null
   title: string | null
   description: string | null
   alt_text: string | null
@@ -53,6 +55,8 @@ export interface PinInsert {
   blog_article_id: string | null
   image_path: string
   media_type?: 'image' | 'video'
+  cover_image_path?: string | null
+  cover_keyframe_seconds?: number | null
   pinterest_board_id?: string | null
   pinterest_board_name?: string | null
   title?: string | null
@@ -70,6 +74,8 @@ export interface PinUpdate {
   status?: PinStatus
   error_message?: string | null
   scheduled_at?: string | null
+  cover_image_path?: string | null
+  cover_keyframe_seconds?: number | null
 }
 
 export interface PinMetadataGeneration {

--- a/src/types/pinterest.ts
+++ b/src/types/pinterest.ts
@@ -58,14 +58,50 @@ export interface PinterestPinResponse {
   media: Record<string, unknown>
 }
 
+/**
+ * Pinterest v5 media_source variants accepted by POST /pins.
+ *
+ * - `image_url`: we host the image somewhere publicly (Supabase Storage) and
+ *   Pinterest fetches it itself. Used for regular image pins.
+ * - `video_id`: we uploaded the video bytes to Pinterest's own S3 bucket via
+ *   POST /media + multipart upload + polling, and pass the resulting media_id
+ *   here. Pinterest does NOT accept a video URL — this is the only video path.
+ *   A cover image is required in practice: supply either a `cover_image_url`
+ *   (we host it) or a `cover_image_key_frame_time` (Pinterest extracts a
+ *   frame server-side at the given second).
+ */
+export type PinterestMediaSource =
+  | { source_type: 'image_url'; url: string }
+  | {
+      source_type: 'video_id'
+      media_id: string
+      cover_image_url?: string
+      cover_image_content_type?: 'image/jpeg' | 'image/png'
+      cover_image_data?: string
+      cover_image_key_frame_time?: number
+      is_standard?: boolean
+    }
+
 export interface PinterestCreatePinPayload {
   board_id: string
   title?: string
   description?: string
   alt_text?: string
   link?: string
-  media_source: {
-    source_type: 'image_url'
-    url: string
-  }
+  media_source: PinterestMediaSource
+}
+
+/** Response from `POST /v5/media` (media upload registration) */
+export interface PinterestMediaRegisterResponse {
+  media_id: string
+  media_type: 'video'
+  upload_url: string
+  upload_parameters: Record<string, string>
+}
+
+/** Response from `GET /v5/media/{media_id}` */
+export interface PinterestMediaStatusResponse {
+  media_id: string
+  media_type: 'video'
+  status: 'registered' | 'processing' | 'succeeded' | 'failed'
 }

--- a/supabase/functions/_shared/ffmpeg-client.ts
+++ b/supabase/functions/_shared/ffmpeg-client.ts
@@ -1,0 +1,93 @@
+/**
+ * Deno client for the external ffmpeg-Docker-API service.
+ *
+ * Mirror of `src/lib/server/ffmpeg-client.ts` — Deno edge functions cannot
+ * import from the Node-side codebase, so the client is duplicated here and
+ * must be kept in sync. See that file for the full interface spec.
+ *
+ * Reads config from Deno.env:
+ *   FFMPEG_SERVER_URL   — base URL of the ffmpeg service
+ *   FFMPEG_SERVER_TOKEN — bearer token
+ */
+
+export interface KeyframeOptions {
+  second?: number
+  format?: 'jpeg' | 'png'
+  quality?: number
+}
+
+export interface KeyframeResult {
+  bytes: Uint8Array
+  contentType: 'image/jpeg' | 'image/png'
+}
+
+function getFfmpegConfig(): { baseUrl: string; token: string } {
+  const baseUrl = Deno.env.get('FFMPEG_SERVER_URL')
+  const token = Deno.env.get('FFMPEG_SERVER_TOKEN')
+  if (!baseUrl) {
+    throw new Error('FFMPEG_SERVER_URL is not configured')
+  }
+  if (!token) {
+    throw new Error('FFMPEG_SERVER_TOKEN is not configured')
+  }
+  return { baseUrl: baseUrl.replace(/\/$/, ''), token }
+}
+
+/**
+ * Ask the ffmpeg server to extract a single frame from `videoUrl` at the
+ * given timestamp and return the image bytes.
+ */
+export async function extractKeyframe(
+  videoUrl: string,
+  options: KeyframeOptions = {}
+): Promise<KeyframeResult> {
+  const { baseUrl, token } = getFfmpegConfig()
+  const second = options.second ?? 1
+  const format = options.format ?? 'jpeg'
+  const body: Record<string, unknown> = {
+    url: videoUrl,
+    second,
+    format,
+  }
+  if (options.quality !== undefined) {
+    body.quality = options.quality
+  }
+
+  const response = await fetch(`${baseUrl}/thumbnail`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: format === 'png' ? 'image/png' : 'image/jpeg',
+    },
+    body: JSON.stringify(body),
+  })
+
+  if (!response.ok) {
+    let detail = `${response.status} ${response.statusText}`
+    try {
+      const errJson = (await response.json()) as {
+        error?: { code?: string; message?: string }
+      }
+      if (errJson?.error?.message) {
+        detail = `${errJson.error.code ?? 'error'}: ${errJson.error.message}`
+      }
+    } catch {
+      // Body wasn't JSON — keep the status line as detail.
+    }
+    throw new Error(`ffmpeg server /thumbnail failed — ${detail}`)
+  }
+
+  const contentType = response.headers.get('content-type') ?? ''
+  if (!contentType.startsWith('image/')) {
+    throw new Error(
+      `ffmpeg server returned unexpected Content-Type: ${contentType || '(none)'}`
+    )
+  }
+
+  const arrayBuffer = await response.arrayBuffer()
+  return {
+    bytes: new Uint8Array(arrayBuffer),
+    contentType: contentType.startsWith('image/png') ? 'image/png' : 'image/jpeg',
+  }
+}

--- a/supabase/functions/_shared/gemini.ts
+++ b/supabase/functions/_shared/gemini.ts
@@ -255,13 +255,14 @@ export async function generatePinMetadata(
   pinImageUrl: string,
   systemPrompt: string | undefined,
   apiKey: string,
-  mediaType: 'image' | 'video' = 'image'
+  mediaType: 'image' | 'video' = 'image',
+  inlineImageData?: { data: string; mimeType: string }
 ): Promise<GeneratedMetadata> {
   const articleSection = articleTitle
     ? `\n\nArticle Title: ${articleTitle}\n\nArticle Content: ${(articleContent ?? '').slice(0, 4000)}`
     : `\n\n[No article linked — generate metadata based solely on the image.]`
   const promptText = `Pin Type: ${mediaType === 'video' ? 'Video' : 'Image'}${articleSection}`
-  const imageData = await fetchImageAsBase64(pinImageUrl)
+  const imageData = inlineImageData ?? await fetchImageAsBase64(pinImageUrl)
 
   const ai = new GoogleGenAI({ apiKey })
   const response = await ai.models.generateContent({

--- a/supabase/functions/_shared/pinterest-api.ts
+++ b/supabase/functions/_shared/pinterest-api.ts
@@ -19,22 +19,47 @@ interface PinterestPinResponse {
   created_at?: string
 }
 
+type PinterestMediaSource =
+  | { source_type: 'image_url'; url: string }
+  | {
+      source_type: 'video_id'
+      media_id: string
+      cover_image_url?: string
+      cover_image_content_type?: 'image/jpeg' | 'image/png'
+      cover_image_data?: string
+      cover_image_key_frame_time?: number
+      is_standard?: boolean
+    }
+
 interface PinterestCreatePinPayload {
   board_id: string
-  media_source: {
-    source_type: 'image_url'
-    url: string
-  }
+  media_source: PinterestMediaSource
   title?: string
   description?: string
   alt_text?: string
   link?: string
 }
 
+interface PinterestMediaRegisterResponse {
+  media_id: string
+  media_type: 'video'
+  upload_url: string
+  upload_parameters: Record<string, string>
+}
+
+interface PinterestMediaStatusResponse {
+  media_id: string
+  media_type: 'video'
+  status: 'registered' | 'processing' | 'succeeded' | 'failed'
+}
+
 export type {
   PinterestTokenResponse,
   PinterestPinResponse,
   PinterestCreatePinPayload,
+  PinterestMediaSource,
+  PinterestMediaRegisterResponse,
+  PinterestMediaStatusResponse,
 }
 
 /**
@@ -115,6 +140,107 @@ export async function createPinterestPin(
   }
 
   throw new Error('Unexpected error in createPinterestPin')
+}
+
+/**
+ * Register a video upload with Pinterest (step 1 of the video publish flow).
+ *
+ * Returns a one-time-use `media_id` plus the signed S3 URL and parameters
+ * needed to upload the actual video bytes.
+ */
+export async function registerPinterestMedia(
+  accessToken: string
+): Promise<PinterestMediaRegisterResponse> {
+  return pinterestFetch<PinterestMediaRegisterResponse>('/media', accessToken, {
+    method: 'POST',
+    body: JSON.stringify({ media_type: 'video' }),
+  })
+}
+
+/**
+ * Upload video bytes to Pinterest's S3 bucket (step 2 of the video publish flow).
+ *
+ * The signed-POST parameters must be appended first, followed by the `file`
+ * field containing the raw bytes — S3 requires this field order.
+ */
+export async function uploadVideoToPinterestS3(
+  register: PinterestMediaRegisterResponse,
+  videoBytes: Uint8Array,
+  filename: string,
+  contentType = 'video/mp4'
+): Promise<void> {
+  const form = new FormData()
+
+  for (const [key, value] of Object.entries(register.upload_parameters)) {
+    form.append(key, value)
+  }
+
+  const blob = new Blob([videoBytes as BlobPart], { type: contentType })
+  form.append('file', blob, filename)
+
+  const response = await fetch(register.upload_url, {
+    method: 'POST',
+    body: form,
+  })
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '')
+    throw new Error(
+      `Pinterest S3 upload failed: ${response.status} ${response.statusText}${
+        errorText ? ` — ${errorText.slice(0, 300)}` : ''
+      }`
+    )
+  }
+}
+
+/**
+ * Get the processing status of a registered Pinterest media upload.
+ */
+export async function getPinterestMediaStatus(
+  accessToken: string,
+  mediaId: string
+): Promise<PinterestMediaStatusResponse> {
+  return pinterestFetch<PinterestMediaStatusResponse>(
+    `/media/${encodeURIComponent(mediaId)}`,
+    accessToken,
+    { method: 'GET' }
+  )
+}
+
+/**
+ * Poll GET /v5/media/{id} until Pinterest reports the upload as `succeeded`.
+ * Backoff: 5s, 10s, 15s, 30s, 30s, ...  Default timeout: 5 minutes.
+ */
+export async function waitForPinterestMediaReady(
+  accessToken: string,
+  mediaId: string,
+  options: { timeoutMs?: number } = {}
+): Promise<PinterestMediaStatusResponse> {
+  const timeoutMs = options.timeoutMs ?? 5 * 60 * 1000
+  const deadline = Date.now() + timeoutMs
+  const backoffSequenceMs = [5_000, 10_000, 15_000, 30_000]
+  let step = 0
+
+  while (true) {
+    const status = await getPinterestMediaStatus(accessToken, mediaId)
+
+    if (status.status === 'succeeded') {
+      return status
+    }
+    if (status.status === 'failed') {
+      throw new Error(`Pinterest media upload failed for media_id=${mediaId}`)
+    }
+
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Pinterest media upload did not reach 'succeeded' within ${timeoutMs}ms (last status: ${status.status})`
+      )
+    }
+
+    const delay = backoffSequenceMs[Math.min(step, backoffSequenceMs.length - 1)]!
+    step++
+    await new Promise((resolve) => setTimeout(resolve, delay))
+  }
 }
 
 /**

--- a/supabase/functions/generate-metadata-single/index.ts
+++ b/supabase/functions/generate-metadata-single/index.ts
@@ -2,6 +2,7 @@ import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
 import { createServiceClient } from '../_shared/supabase.ts'
 import { corsHeaders, handleCors } from '../_shared/cors.ts'
 import { generatePinMetadata, sanitizeLanguage, buildPinterestSeoSystemPrompt } from '../_shared/gemini.ts'
+import { extractKeyframe } from '../_shared/ffmpeg-client.ts'
 
 interface MetadataRequest {
   pin_id: string
@@ -80,6 +81,19 @@ Deno.serve(async (req) => {
     const ext = pin.image_path.split('.').pop()?.toLowerCase() ?? ''
     const mediaType = ['mp4', 'mov', 'avi', 'webm'].includes(ext) ? 'video' : 'image'
 
+    // For video pins: extract a keyframe and pass it to Gemini instead of the raw video
+    let inlineImageData: { data: string; mimeType: string } | undefined
+    if (mediaType === 'video') {
+      const keyframe = await extractKeyframe(imageUrl, { second: pin.cover_keyframe_seconds ?? 1 })
+      // Deno-compatible chunked btoa
+      const chunkSize = 8192
+      let binary = ''
+      for (let i = 0; i < keyframe.bytes.length; i += chunkSize) {
+        binary += String.fromCharCode(...keyframe.bytes.subarray(i, i + chunkSize))
+      }
+      inlineImageData = { data: btoa(binary), mimeType: keyframe.contentType }
+    }
+
     // Generate metadata with Gemini (article may be null)
     const metadata = await generatePinMetadata(
       pin.blog_articles?.title ?? null,
@@ -87,7 +101,8 @@ Deno.serve(async (req) => {
       imageUrl,
       systemPrompt,
       apiKey,
-      mediaType
+      mediaType,
+      inlineImageData
     )
 
     // Insert generation history

--- a/supabase/functions/publish-scheduled-pins/index.ts
+++ b/supabase/functions/publish-scheduled-pins/index.ts
@@ -3,7 +3,11 @@ import { createServiceClient } from '../_shared/supabase.ts'
 import { corsHeaders, handleCors } from '../_shared/cors.ts'
 import {
   createPinterestPin,
+  registerPinterestMedia,
+  uploadVideoToPinterestS3,
+  waitForPinterestMediaReady,
   type PinterestCreatePinPayload,
+  type PinterestMediaSource,
 } from '../_shared/pinterest-api.ts'
 import { notifyPinError } from '../_shared/notifications.ts'
 
@@ -130,16 +134,49 @@ Deno.serve(async (req) => {
         const pin = connectionPins[i]
 
         try {
-          // Build image URL
-          const imagePublicUrl = `${supabaseUrl}/storage/v1/object/public/pin-images/${pin.image_path}`
+          const mediaPublicUrl = `${supabaseUrl}/storage/v1/object/public/pin-images/${pin.image_path}`
+
+          let mediaSource: PinterestMediaSource
+
+          if (pin.media_type === 'video') {
+            // Step 1: Register a media slot with Pinterest
+            const registration = await registerPinterestMedia(accessToken)
+
+            // Step 2: Fetch video bytes from Supabase Storage
+            const videoResponse = await fetch(mediaPublicUrl)
+            if (!videoResponse.ok) {
+              throw new Error(
+                `Failed to fetch video from storage: ${videoResponse.status} ${videoResponse.statusText}`
+              )
+            }
+            const videoBytes = new Uint8Array(await videoResponse.arrayBuffer())
+            const filename = (pin.image_path as string).split('/').pop() ?? 'video.mp4'
+
+            // Step 3: Upload bytes to Pinterest's S3
+            await uploadVideoToPinterestS3(registration, videoBytes, filename)
+
+            // Step 4: Poll until Pinterest finishes processing
+            await waitForPinterestMediaReady(accessToken, registration.media_id)
+
+            // Step 5: Build video source with cover
+            const videoSource: Extract<PinterestMediaSource, { source_type: 'video_id' }> = {
+              source_type: 'video_id',
+              media_id: registration.media_id,
+            }
+            if (pin.cover_image_path) {
+              videoSource.cover_image_url = `${supabaseUrl}/storage/v1/object/public/pin-images/${pin.cover_image_path}`
+            } else {
+              videoSource.cover_image_key_frame_time = pin.cover_keyframe_seconds ?? 1
+            }
+            mediaSource = videoSource
+          } else {
+            mediaSource = { source_type: 'image_url', url: mediaPublicUrl }
+          }
 
           // Build Pinterest API payload
           const payload: PinterestCreatePinPayload = {
             board_id: pin.pinterest_board_id,
-            media_source: {
-              source_type: 'image_url',
-              url: imagePublicUrl,
-            },
+            media_source: mediaSource,
           }
 
           if (pin.title) {

--- a/supabase/migrations/00022_pin_video_support.sql
+++ b/supabase/migrations/00022_pin_video_support.sql
@@ -1,0 +1,39 @@
+-- ============================================================================
+-- Migration: Pinterest video publishing support
+-- ============================================================================
+-- Adds:
+--   - pins.media_type              -- 'image' | 'video' (default 'image')
+--   - pins.cover_image_path        -- optional user-uploaded cover for videos;
+--                                     stored in the pin-images bucket like
+--                                     regular pin media
+--   - pins.cover_keyframe_seconds  -- fallback when cover_image_path is NULL:
+--                                     extract the video frame at this second
+--                                     (via the external ffmpeg server) and
+--                                     use it as the Pinterest cover thumbnail
+--
+-- The TypeScript type in src/types/pins.ts already declared `media_type` but
+-- the column did not exist in the DB, so it was silently dropped on every
+-- insert. This migration makes the schema match the types.
+--
+-- Backfill: default 'image' covers every existing row. RLS policies on pins
+-- remain unchanged (same tenant_id scope).
+
+BEGIN;
+
+ALTER TABLE public.pins
+  ADD COLUMN IF NOT EXISTS media_type text NOT NULL DEFAULT 'image'
+    CHECK (media_type IN ('image', 'video')),
+  ADD COLUMN IF NOT EXISTS cover_image_path text,
+  ADD COLUMN IF NOT EXISTS cover_keyframe_seconds integer DEFAULT 1
+    CHECK (cover_keyframe_seconds IS NULL OR cover_keyframe_seconds >= 0);
+
+COMMENT ON COLUMN public.pins.media_type IS
+  'Media kind for this pin. Drives the Pinterest publish path: ''image'' uses source_type=image_url, ''video'' registers media with Pinterest, uploads the file, and uses source_type=video_id.';
+
+COMMENT ON COLUMN public.pins.cover_image_path IS
+  'Optional user-uploaded cover image for video pins (path inside the pin-images bucket). When NULL, the publish flow falls back to extracting a frame from the video at cover_keyframe_seconds via the external ffmpeg server.';
+
+COMMENT ON COLUMN public.pins.cover_keyframe_seconds IS
+  'Fallback cover source for video pins without a cover_image_path: the second (integer) at which to extract a keyframe. Defaults to 1 second.';
+
+COMMIT;


### PR DESCRIPTION
## Summary

- **Publish flow**: beide Publish-Paths (Node `publishSinglePin` + Deno Edge Function `publish-scheduled-pins`) erkennen `media_type='video'` und durchlaufen den vollstaendigen Pinterest v5 Video-Flow: `POST /media` → S3 multipart upload → polling bis `succeeded` → `POST /pins` mit `source_type=video_id` + Cover (eigenes Bild oder `cover_image_key_frame_time`)
- **Gemini-Metadata**: Video-Pins senden nicht mehr das rohe MP4 an Gemini, sondern einen per ffmpeg-Server extrahierten Keyframe (JPEG) — alle 4 Callsites (Node metadata.ts, Trigger.dev Task, Deno Edge Function) aktualisiert
- **UI**: `cover_keyframe_seconds`-Feld im EditPinDialog (nur fuer Video-Pins sichtbar), Info-Zeile im Pin-Detail-View, i18n de + en
- **E2E-Test**: `scripts/test-video-publish.ts` verifiziert den kompletten Flow — live getestet, Pin `901845894201109907` erfolgreich auf Pinterest veroeffentlicht

## DB-Voraussetzung

Migration `00022_pin_video_support.sql` muss applied sein (wurde in der vorherigen Session gemacht):
- `pins.media_type` (`'image' | 'video'`, default `'image'`)
- `pins.cover_image_path` (optional, user-uploaded cover)
- `pins.cover_keyframe_seconds` (fallback: Pinterest extrahiert Frame server-seitig)

## Test plan

- [ ] `npm test` — 293 Tests gruen
- [ ] E2E: `npx tsx scripts/test-video-publish.ts --dry-run` prueft Token-Fetch
- [ ] E2E live: `npx tsx scripts/test-video-publish.ts` published echten Video-Pin
- [ ] UI: EditPinDialog eines Video-Pins zeigt "Cover-Keyframe"-Feld
- [ ] UI: Pin-Detail-View zeigt Cover-Keyframe-Info fuer Video-Pins

🤖 Generated with [Claude Code](https://claude.com/claude-code)