### PR TITLE
Release v1.9.2 — AI SDK v6 upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "petra-pinterest",
       "version": "1.9.1",
       "dependencies": {
-        "@ai-sdk/google": "^2.0.74",
+        "@ai-sdk/google": "^3.0.80",
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -32,7 +32,7 @@
         "@tanstack/react-router-devtools": "^1.157.16",
         "@tanstack/react-start": "^1.157.16",
         "@trigger.dev/sdk": "^4.4.2",
-        "ai": "^5.0.196",
+        "ai": "^6.0.199",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -107,14 +107,14 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "2.0.97",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.97.tgz",
-      "integrity": "sha512-8lM9IuiUcYNw9aYKKsD9Rwr7tfbBxIgsCNlktGBGS7IQHe7bLbK0AZzQKKVWz3JxJn/nhVbGtiFNt3fUnHahvQ==",
+      "version": "3.0.127",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.127.tgz",
+      "integrity": "sha512-Obmw5hmE5x+ccRrMp/Djx5r0rpFVX87YqE6OY06g5fwYlRI30dA84ARfTzX45ivCvkW4eCnBpOVXVWQ/pjH85w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.3",
-        "@ai-sdk/provider-utils": "3.0.25",
-        "@vercel/oidc": "3.1.0"
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@vercel/oidc": "3.2.0"
       },
       "engines": {
         "node": ">=18"
@@ -124,13 +124,13 @@
       }
     },
     "node_modules/@ai-sdk/google": {
-      "version": "2.0.74",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-2.0.74.tgz",
-      "integrity": "sha512-Lhw1742RXc+4pRIvqVXa0jdl5+qdpmw8lj0lm6OchUg9rVGHzymlaxe7CDiYX5U2af4jbjKeTY22LDi3bIycgQ==",
+      "version": "3.0.80",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.80.tgz",
+      "integrity": "sha512-5ORbm/yFUPO0MEvZsxBMN0cdKw2+lwU/wVn5KN3KF8Dmk1LughuDuUohMh/7iU/XFTiyB0OvmTW/tdV/J7O9zg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.3",
-        "@ai-sdk/provider-utils": "3.0.25"
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
       },
       "engines": {
         "node": ">=18"
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.3.tgz",
-      "integrity": "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -152,14 +152,14 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.25",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.25.tgz",
-      "integrity": "sha512-CvsRu+32Y8a167s+lrIBtsybvgTHp8j9y+6BeTvLeoW3Q+okw/b4CnNUFOLIXsRaKHQKAH+IHNJPYWywfpw0LA==",
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
+      "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.3",
-        "@standard-schema/spec": "^1.0.0",
-        "eventsource-parser": "^3.0.6"
+        "@ai-sdk/provider": "3.0.10",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -6317,9 +6317,9 @@
       }
     },
     "node_modules/@vercel/oidc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
-      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20"
@@ -6520,15 +6520,15 @@
       }
     },
     "node_modules/ai": {
-      "version": "5.0.196",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.196.tgz",
-      "integrity": "sha512-JaljZ1/UagJ1oJp8CcMDxXoE2E2pv4Q/hETkhcD8aE15pbnO7KhEeIqLgsQEizJjc5AquS7matl6GfnDQUDUpA==",
+      "version": "6.0.199",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.199.tgz",
+      "integrity": "sha512-6H9RPEjzBQECM+eU1JxAh6jHcZPU/6q5QZ8D8QV8agubf0Mm/kcBlwqrFcFtup6RQzmEvMkVaQOoLCZ8bQ13lA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "2.0.97",
-        "@ai-sdk/provider": "2.0.3",
-        "@ai-sdk/provider-utils": "3.0.25",
-        "@opentelemetry/api": "1.9.0"
+        "@ai-sdk/gateway": "3.0.127",
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@opentelemetry/api": "^1.9.0"
       },
       "engines": {
         "node": ">=18"
@@ -8435,9 +8435,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "petra-pinterest",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "petra-pinterest",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "dependencies": {
         "@ai-sdk/google": "^3.0.80",
         "@hookform/resolvers": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "petra-pinterest",
   "private": true,
-  "version": "1.9.1",
+  "version": "1.9.2",
   "type": "module",
   "scripts": {
     "dev": "node --max-http-header-size=32768 node_modules/vite/bin/vite.js dev --port 3000",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:notifications": "node --env-file=.env.local scripts/test-error-notification.mjs"
   },
   "dependencies": {
-    "@ai-sdk/google": "^2.0.74",
+    "@ai-sdk/google": "^3.0.80",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-checkbox": "^1.3.3",
@@ -38,7 +38,7 @@
     "@tanstack/react-router-devtools": "^1.157.16",
     "@tanstack/react-start": "^1.157.16",
     "@trigger.dev/sdk": "^4.4.2",
-    "ai": "^5.0.196",
+    "ai": "^6.0.199",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/src/lib/ai/generate.test.ts
+++ b/src/lib/ai/generate.test.ts
@@ -1,4 +1,4 @@
-import { MockLanguageModelV2 } from 'ai/test'
+import { MockLanguageModelV3 } from 'ai/test'
 import {
   generateArticleFromHtml,
   generatePinMetadata,
@@ -7,10 +7,10 @@ import {
 import { getRepairFireCount, resetRepairFireCount } from './repair'
 
 function mockModelReturning(text: string) {
-  return new MockLanguageModelV2({
+  return new MockLanguageModelV3({
     doGenerate: async () => ({
-      finishReason: 'stop',
-      usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      finishReason: { unified: 'stop', raw: undefined },
+      usage: { inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined }, outputTokens: { total: 20, text: 20, reasoning: undefined } },
       content: [{ type: 'text', text }],
       warnings: [],
     }),
@@ -61,12 +61,12 @@ describe('generateArticleFromHtml()', () => {
 
   it('passes the URL through to the model prompt', async () => {
     let seenPrompt = ''
-    const model = new MockLanguageModelV2({
+    const model = new MockLanguageModelV3({
       doGenerate: async (options) => {
         seenPrompt = JSON.stringify(options.prompt)
         return {
-          finishReason: 'stop',
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          finishReason: { unified: 'stop', raw: undefined },
+          usage: { inputTokens: { total: 1, noCache: 1, cacheRead: undefined, cacheWrite: undefined }, outputTokens: { total: 1, text: 1, reasoning: undefined } },
           content: [{ type: 'text', text: JSON.stringify(article) }],
           warnings: [],
         }
@@ -126,12 +126,12 @@ describe('generatePinMetadata()', () => {
 
   it('produces the image-only prompt when no article is linked', async () => {
     let seenPrompt = ''
-    const model = new MockLanguageModelV2({
+    const model = new MockLanguageModelV3({
       doGenerate: async (options) => {
         seenPrompt = JSON.stringify(options.prompt)
         return {
-          finishReason: 'stop',
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          finishReason: { unified: 'stop', raw: undefined },
+          usage: { inputTokens: { total: 1, noCache: 1, cacheRead: undefined, cacheWrite: undefined }, outputTokens: { total: 1, text: 1, reasoning: undefined } },
           content: [{ type: 'text', text: JSON.stringify(metadata) }],
           warnings: [],
         }
@@ -155,12 +155,12 @@ describe('generatePinMetadata()', () => {
   it('flows video keyframe bytes through the same image part and marks the video pin type', async () => {
     let seenPrompt: any = null
     const keyframe = { bytes: new Uint8Array([9, 8, 7]), mimeType: 'image/jpeg' }
-    const model = new MockLanguageModelV2({
+    const model = new MockLanguageModelV3({
       doGenerate: async (options) => {
         seenPrompt = options.prompt
         return {
-          finishReason: 'stop',
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          finishReason: { unified: 'stop', raw: undefined },
+          usage: { inputTokens: { total: 1, noCache: 1, cacheRead: undefined, cacheWrite: undefined }, outputTokens: { total: 1, text: 1, reasoning: undefined } },
           content: [{ type: 'text', text: JSON.stringify(metadata) }],
           warnings: [],
         }
@@ -202,12 +202,12 @@ describe('generatePinMetadataWithFeedback()', () => {
 
   it('builds a [user, assistant, user] message sequence and returns refined validated metadata', async () => {
     let seenPrompt: any = null
-    const model = new MockLanguageModelV2({
+    const model = new MockLanguageModelV3({
       doGenerate: async (options) => {
         seenPrompt = options.prompt
         return {
-          finishReason: 'stop',
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          finishReason: { unified: 'stop', raw: undefined },
+          usage: { inputTokens: { total: 1, noCache: 1, cacheRead: undefined, cacheWrite: undefined }, outputTokens: { total: 1, text: 1, reasoning: undefined } },
           content: [{ type: 'text', text: JSON.stringify(refined) }],
           warnings: [],
         }

--- a/src/lib/ai/generate.ts
+++ b/src/lib/ai/generate.ts
@@ -1,17 +1,17 @@
 /**
- * Public AI operations as options-object wrappers over `generateObject`
+ * Public AI operations as options-object wrappers over `generateText` + `Output.object`
  * (ADR 0002 / PRD #40).
  *
  * Slice 1 ships article extraction only; pin-metadata wrappers land in a later
  * slice. Each wrapper accepts an optional injected `model` so tests can exercise
- * the real `generateObject` + Zod + repair path via `MockLanguageModelV2` with
+ * the real `generateText` + Output + Zod + repair path via `MockLanguageModelV3` with
  * no network. Production calls resolve the model from the BYOK key via
  * `getModel(apiKey)`.
  */
 
-import { generateObject, type LanguageModel, type ModelMessage } from 'ai'
+import { generateText, type LanguageModel, type ModelMessage } from 'ai'
 import { getModel } from './model'
-import { repairText } from './repair'
+import { repairableObject } from './output'
 import { ARTICLE_SCRAPER_SYSTEM_PROMPT, PINTEREST_SEO_SYSTEM_PROMPT } from './prompts'
 import {
   scrapedArticleSchema,
@@ -35,7 +35,7 @@ export interface GenerateArticleOptions {
 /**
  * Extract structured article content from raw HTML.
  *
- * Wraps `generateObject` with the article Zod schema and the article-scraper
+ * Wraps `generateText` + `Output.object` with the article Zod schema and the article-scraper
  * system prompt at `temperature: 0.1`. No manual `JSON.parse` on the happy
  * path; the carried-over control-char repair only fires on parse failure.
  */
@@ -47,16 +47,15 @@ export async function generateArticleFromHtml({
 }: GenerateArticleOptions): Promise<ScrapedArticle> {
   const truncatedHtml = html.slice(0, MAX_HTML_CHARS)
 
-  const { object } = await generateObject({
+  const { output } = await generateText({
     model: model ?? getModel(apiKey),
-    schema: scrapedArticleSchema,
+    output: repairableObject(scrapedArticleSchema),
     system: ARTICLE_SCRAPER_SYSTEM_PROMPT,
     prompt: `URL: ${url}\n\nHTML Content:\n${truncatedHtml}`,
     temperature: 0.1,
-    experimental_repairText: repairText,
   })
 
-  return object
+  return output
 }
 
 export interface PinMetadataArticle {
@@ -115,7 +114,7 @@ function buildPinMetadataUserMessage({
 }
 
 /**
- * Shared `generateObject` call for both pin-metadata paths.
+ * Shared `generateText` + `Output.object` call for both pin-metadata paths.
  *
  * Wraps the metadata Zod schema with the same temperature, token, and Google
  * provider-option settings the old `@google/genai` path used (`thinkingBudget: 0`,
@@ -126,18 +125,17 @@ async function generatePinMetadataObject(
   messages: ModelMessage[],
   { model, apiKey, systemPrompt }: Pick<GeneratePinMetadataOptions, 'model' | 'apiKey' | 'systemPrompt'>,
 ): Promise<GeneratedMetadata> {
-  const { object } = await generateObject({
+  const { output } = await generateText({
     model: model ?? getModel(apiKey),
-    schema: generatedMetadataSchema,
+    output: repairableObject(generatedMetadataSchema),
     system: systemPrompt || PINTEREST_SEO_SYSTEM_PROMPT,
     messages,
     temperature: 0.7,
     maxOutputTokens: 8192,
     providerOptions: { google: { thinkingConfig: { thinkingBudget: 0 } } },
-    experimental_repairText: repairText,
   })
 
-  return object
+  return output
 }
 
 /**

--- a/src/lib/ai/output.ts
+++ b/src/lib/ai/output.ts
@@ -1,0 +1,38 @@
+/**
+ * Repair-preserving structured `Output` for the `generateText` path.
+ *
+ * AI SDK v6 deprecated `generateObject` in favor of `generateText({ output })`.
+ * The old `experimental_repairText` slot lived only on `generateObject`, and
+ * `Output.object` exposes no repair hook. This wraps `Output.object` and runs
+ * the carried-over control-char repair inside `parseCompleteOutput` when the
+ * first parse/validation fails — same net behavior and fire-counter as before:
+ * native parse first, repair only on failure (ADR 0002 / PRD #40).
+ */
+
+import { Output } from 'ai'
+import type { z } from 'zod'
+import { repairText } from './repair'
+
+/**
+ * Like `Output.object({ schema })`, but a failed parse triggers one
+ * control-char-repair retry before giving up.
+ */
+export function repairableObject<SCHEMA extends z.ZodType>(schema: SCHEMA) {
+  const inner = Output.object<z.infer<SCHEMA>>({ schema })
+  const parse = inner.parseCompleteOutput.bind(inner)
+
+  inner.parseCompleteOutput = async (options, context) => {
+    try {
+      return await parse(options, context)
+    } catch (error) {
+      const repaired = await repairText({
+        text: options.text,
+        error: error as Parameters<typeof repairText>[0]['error'],
+      })
+      if (repaired == null || repaired === options.text) throw error
+      return parse({ ...options, text: repaired }, context)
+    }
+  }
+
+  return inner
+}

--- a/src/lib/ai/repair.ts
+++ b/src/lib/ai/repair.ts
@@ -3,7 +3,7 @@
  *
  * Carries over the former `sanitizeJsonResponse` control-char logic from the
  * `@google/genai` path into the AI SDK's sanctioned `experimental_repairText`
- * slot. The native `generateObject` parse runs first; this only fires when that
+ * slot. The native `Output.object` parse runs first; this only fires when that
  * parse (or Zod validation) fails. A fire-counter lets us measure, weeks later,
  * whether the AI SDK already fixes the Gemini flakiness so the hack can be
  * deleted (see ADR 0002 / PRD #40).
@@ -98,7 +98,7 @@ export function sanitizeJsonControlChars(text: string): string {
 }
 
 /**
- * `experimental_repairText` callback for `generateObject`. Fires only when the
+ * Repair callback reused by `repairableObject` on the `generateText` path. Fires only when the
  * model output fails to parse/validate; increments the fire-counter and returns
  * the control-char-sanitized text for a second parse attempt.
  */

--- a/src/lib/ai/schemas.ts
+++ b/src/lib/ai/schemas.ts
@@ -1,7 +1,7 @@
 /**
  * Zod schemas for AI structured output (re-homed from lib/gemini, unchanged).
  *
- * Used as `generateObject` schemas so the happy path is parsed + validated
+ * Used as `Output.object` schemas so the happy path is parsed + validated
  * natively, with no manual `JSON.parse` of model output (ADR 0002 / PRD #40).
  */
 

--- a/supabase/functions/_shared/ai.test.ts
+++ b/supabase/functions/_shared/ai.test.ts
@@ -1,4 +1,4 @@
-import { MockLanguageModelV2 } from 'ai/test'
+import { MockLanguageModelV3 } from 'ai/test'
 import {
   fetchImageBytes,
   generateArticleFromHtml,
@@ -15,10 +15,10 @@ import {
 // `npm:` specifiers; vitest aliases map those onto the installed Node packages.
 
 function mockModelReturning(text: string) {
-  return new MockLanguageModelV2({
+  return new MockLanguageModelV3({
     doGenerate: async () => ({
-      finishReason: 'stop',
-      usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      finishReason: { unified: 'stop', raw: undefined },
+      usage: { inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined }, outputTokens: { total: 20, text: 20, reasoning: undefined } },
       content: [{ type: 'text', text }],
       warnings: [],
     }),
@@ -126,12 +126,12 @@ describe('generateArticleFromHtml() [edge mirror]', () => {
 
   it('passes the URL through to the model prompt', async () => {
     let seenPrompt = ''
-    const model = new MockLanguageModelV2({
+    const model = new MockLanguageModelV3({
       doGenerate: async (options) => {
         seenPrompt = JSON.stringify(options.prompt)
         return {
-          finishReason: 'stop',
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          finishReason: { unified: 'stop', raw: undefined },
+          usage: { inputTokens: { total: 1, noCache: 1, cacheRead: undefined, cacheWrite: undefined }, outputTokens: { total: 1, text: 1, reasoning: undefined } },
           content: [{ type: 'text', text: JSON.stringify(article) }],
           warnings: [],
         }
@@ -183,12 +183,12 @@ describe('generatePinMetadata() [edge mirror]', () => {
 
   it('produces the image-only prompt when no article is linked', async () => {
     let seenPrompt = ''
-    const model = new MockLanguageModelV2({
+    const model = new MockLanguageModelV3({
       doGenerate: async (options) => {
         seenPrompt = JSON.stringify(options.prompt)
         return {
-          finishReason: 'stop',
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          finishReason: { unified: 'stop', raw: undefined },
+          usage: { inputTokens: { total: 1, noCache: 1, cacheRead: undefined, cacheWrite: undefined }, outputTokens: { total: 1, text: 1, reasoning: undefined } },
           content: [{ type: 'text', text: JSON.stringify(metadata) }],
           warnings: [],
         }
@@ -212,12 +212,12 @@ describe('generatePinMetadata() [edge mirror]', () => {
   it('flows video keyframe bytes through the same image part and marks the video pin type', async () => {
     let seenPrompt: any = null
     const keyframe = { bytes: new Uint8Array([9, 8, 7]), mimeType: 'image/jpeg' }
-    const model = new MockLanguageModelV2({
+    const model = new MockLanguageModelV3({
       doGenerate: async (options) => {
         seenPrompt = options.prompt
         return {
-          finishReason: 'stop',
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          finishReason: { unified: 'stop', raw: undefined },
+          usage: { inputTokens: { total: 1, noCache: 1, cacheRead: undefined, cacheWrite: undefined }, outputTokens: { total: 1, text: 1, reasoning: undefined } },
           content: [{ type: 'text', text: JSON.stringify(metadata) }],
           warnings: [],
         }

--- a/supabase/functions/_shared/ai.ts
+++ b/supabase/functions/_shared/ai.ts
@@ -12,7 +12,8 @@
  */
 
 import {
-  generateObject,
+  generateText,
+  Output,
   type LanguageModel,
   type RepairTextFunction,
 } from 'npm:ai'
@@ -124,13 +125,39 @@ export function sanitizeJsonControlChars(text: string): string {
 }
 
 /**
- * `experimental_repairText` callback for `generateObject`. Fires only when the
+ * Repair callback reused by `repairableObject` on the `generateText` path. Fires only when the
  * model output fails to parse/validate; increments the fire-counter and returns
  * the control-char-sanitized text for a second parse attempt.
  */
 export const repairText: RepairTextFunction = async ({ text }) => {
   repairFireCount++
   return sanitizeJsonControlChars(text)
+}
+
+/**
+ * Like `Output.object({ schema })`, but a failed parse triggers one
+ * control-char-repair retry before giving up. v6 moved structured generation to
+ * `generateText({ output })` and `Output.object` has no repair hook, so the
+ * repair net lives here (mirror of lib/ai/output.ts).
+ */
+function repairableObject<SCHEMA extends z.ZodType>(schema: SCHEMA) {
+  const inner = Output.object<z.infer<SCHEMA>>({ schema })
+  const parse = inner.parseCompleteOutput.bind(inner)
+
+  inner.parseCompleteOutput = async (options, context) => {
+    try {
+      return await parse(options, context)
+    } catch (error) {
+      const repaired = await repairText({
+        text: options.text,
+        error: error as Parameters<typeof repairText>[0]['error'],
+      })
+      if (repaired == null || repaired === options.text) throw error
+      return parse({ ...options, text: repaired }, context)
+    }
+  }
+
+  return inner
 }
 
 // --- Image bytes helper (mirror of lib/ai/image.ts) ---
@@ -329,7 +356,7 @@ export interface GenerateArticleOptions {
 /**
  * Extract structured article content from raw HTML.
  *
- * Wraps `generateObject` with the article Zod schema and the article-scraper
+ * Wraps `generateText` + `Output.object` with the article Zod schema and the article-scraper
  * system prompt at `temperature: 0.1`. No manual `JSON.parse` on the happy
  * path; the carried-over control-char repair only fires on parse failure.
  */
@@ -341,16 +368,15 @@ export async function generateArticleFromHtml({
 }: GenerateArticleOptions): Promise<ScrapedArticle> {
   const truncatedHtml = html.slice(0, MAX_HTML_CHARS)
 
-  const { object } = await generateObject({
+  const { output } = await generateText({
     model: model ?? getModel(apiKey),
-    schema: scrapedArticleSchema,
+    output: repairableObject(scrapedArticleSchema),
     system: ARTICLE_SCRAPER_SYSTEM_PROMPT,
     prompt: `URL: ${url}\n\nHTML Content:\n${truncatedHtml}`,
     temperature: 0.1,
-    experimental_repairText: repairText,
   })
 
-  return object
+  return output
 }
 
 export interface PinMetadataArticle {
@@ -394,7 +420,7 @@ function buildPinMetadataPromptText({
  * Generate Pinterest-optimized metadata (title, description, alt text) for a pin.
  *
  * Builds a multimodal prompt — a text section plus a `Uint8Array` image part —
- * and wraps `generateObject` with the metadata Zod schema. Image and video pins
+ * and wraps `generateText` + `Output.object` with the metadata Zod schema. Image and video pins
  * share the same image part (video pins pass the ffmpeg keyframe bytes). The
  * Google `thinkingBudget: 0` and `temperature: 0.7` behavior is preserved via
  * provider options; the control-char repair only fires on parse failure.
@@ -409,9 +435,9 @@ export async function generatePinMetadata({
 }: GeneratePinMetadataOptions): Promise<GeneratedMetadata> {
   const promptText = buildPinMetadataPromptText({ article, mediaType })
 
-  const { object } = await generateObject({
+  const { output } = await generateText({
     model: model ?? getModel(apiKey),
-    schema: generatedMetadataSchema,
+    output: repairableObject(generatedMetadataSchema),
     system: systemPrompt || PINTEREST_SEO_SYSTEM_PROMPT,
     messages: [
       {
@@ -425,8 +451,7 @@ export async function generatePinMetadata({
     temperature: 0.7,
     maxOutputTokens: 8192,
     providerOptions: { google: { thinkingConfig: { thinkingBudget: 0 } } },
-    experimental_repairText: repairText,
   })
 
-  return object
+  return output
 }


### PR DESCRIPTION
Bumps version to **v1.9.2**.

## AI SDK v6 upgrade + generateObject migration

- `ai` ^5.0.196 → **^6.0.199**, `@ai-sdk/google` ^2.0.74 → **^3.0.80**
- Migrated `generateObject` → `generateText` + `Output.object` in both the Node (`src/lib/ai`) and Deno edge (`_shared/ai.ts`) runtimes; result via `.output`.
- New `repairableObject()` wraps `Output.object` to preserve the control-char JSON repair net. v6 dropped `experimental_repairText` from the structured-output path (it only existed on the now-deprecated `generateObject`), so repair now runs inside `parseCompleteOutput` on parse failure — same net behavior + fire-counter (ADR 0002).
- Test mocks `MockLanguageModelV2` → `MockLanguageModelV3` with the V3 result shape (`finishReason {unified,raw}`, nested `usage`).
- Removed untracked `.sandcastle/worktrees`+`logs` cruft that double-ran the suite.

BYOK Gemini, Vault, and the `get_gemini_api_key` RPC are unchanged — no DB migration.

## Verification
- `tsc` clean for `lib/ai` ✓
- vitest **275/275** ✓
- production build ✓
- `deno check _shared/ai.ts` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)